### PR TITLE
Compress param per spec, since SAMLEncoding param is ommitted

### DIFF
--- a/saml.go
+++ b/saml.go
@@ -2,6 +2,7 @@ package saml2
 
 import (
 	"bytes"
+	"compress/flate"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -97,9 +98,26 @@ func (sp *SAMLServiceProvider) BuildAuthURL(relayState string) (string, error) {
 		return "", err
 	}
 
+	buf := &bytes.Buffer{}
+
+	fw, err := flate.NewWriter(buf, flate.DefaultCompression)
+	if err != nil {
+		return "", fmt.Errorf("flate NewWriter error: %v", err)
+	}
+
+	_, err = fw.Write([]byte(authnRequest))
+	if err != nil {
+		return "", fmt.Errorf("flate.Writer Write error: %v", err)
+	}
+
+	err = fw.Close()
+	if err != nil {
+		return "", fmt.Errorf("flate.Writer Close error: %v", err)
+	}
+
 	qs := parsedUrl.Query()
 
-	qs.Add("SAMLRequest", base64.StdEncoding.EncodeToString([]byte(authnRequest)))
+	qs.Add("SAMLRequest", base64.StdEncoding.EncodeToString(buf.Bytes()))
 
 	if relayState != "" {
 		qs.Add("RelayState", relayState)


### PR DESCRIPTION
This satisfies line 568 of
https://docs.oasis-open.org/security/saml/v2.0/saml-bindings-2.0-os.pdf

This is quite an important bit for Shibboleth support, as it will throw an error when the encoding is wrong rather than falling back gracefully. Of course, it also makes for a smaller round-trip payload, so definitely helpful. :-)

Let me know if I can do anything else to shore things up!