### PR TITLE
Add Zulu prefix for UTC dates

### DIFF
--- a/saml.go
+++ b/saml.go
@@ -2,7 +2,7 @@ package saml2
 
 import dsig "github.com/russellhaering/goxmldsig"
 
-const issueInstantFormat = "2006-01-02T15:04:05"
+const issueInstantFormat = "2006-01-02T15:04:05Z"
 
 type SAMLServiceProvider struct {
 	IdentityProviderSSOURL      string


### PR DESCRIPTION
For some reason, UTC dates without the -Z suffix cause my local Shibboleth site to break.