### PR TITLE
Should {AssertionConsumer,AttributeConsuming}ServiceIndex be removed?

### DIFF
--- a/build_request.go
+++ b/build_request.go
@@ -25,8 +25,6 @@ func (sp *SAMLServiceProvider) BuildAuthRequest() (string, error) {
 	authnRequest.CreateAttr("Version", "2.0")
 	authnRequest.CreateAttr("ProtocolBinding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST")
 	authnRequest.CreateAttr("AssertionConsumerServiceURL", sp.AssertionConsumerServiceURL)
-	authnRequest.CreateAttr("AssertionConsumerServiceIndex", "0")
-	authnRequest.CreateAttr("AttributeConsumingServiceIndex", "0")
 	authnRequest.CreateAttr("IssueInstant", time.Now().UTC().Format(issueInstantFormat))
 	authnRequest.CreateAttr("Destination", sp.IdentityProviderSSOURL)
 	authnRequest.CreateElement("saml:Issuer").SetText(sp.IdentityProviderIssuer)


### PR DESCRIPTION
For some reason, these attributes cause things to go funny in my local site, and I'm not sure what they do. Can they be removed? If not, I can also add more tuning as a flag.