### PR TITLE
Add AuthRedirect method, tests, and AuthNRequest type

### DIFF
--- a/authn_request.go
+++ b/authn_request.go
@@ -1,0 +1,16 @@
+package saml2
+
+import "time"
+
+// AuthNRequest is the go struct representation of an authentication request
+type AuthNRequest struct {
+	ID                          string `xml:",attr"`
+	Version                     string `xml:",attr"`
+	ProtocolBinding             string `xml:",attr"`
+	AssertionConsumerServiceURL string `xml:",attr"`
+
+	IssueInstant time.Time `xml:",attr"`
+
+	Destination string `xml:",attr"`
+	Issuer      string
+}

--- a/build_request.go
+++ b/build_request.go
@@ -5,6 +5,7 @@ import (
 	"compress/flate"
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -104,4 +105,17 @@ func (sp *SAMLServiceProvider) BuildAuthURL(relayState string) (string, error) {
 
 	parsedUrl.RawQuery = qs.Encode()
 	return parsedUrl.String(), nil
+}
+
+// AuthRedirect takes a ResponseWriter and Request from an http interaction and
+// redirects to the SAMLServiceProvider's configured IdP, including the
+// relayState provided, if any.
+func (sp *SAMLServiceProvider) AuthRedirect(w http.ResponseWriter, r *http.Request, relayState string) (err error) {
+	url, err := sp.BuildAuthURL(relayState)
+	if err != nil {
+		return err
+	}
+
+	http.Redirect(w, r, url, http.StatusFound)
+	return nil
 }

--- a/build_request_test.go
+++ b/build_request_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestRedirect(t *testing.T) {
-	r := &http.Request{}
+	r := &http.Request{URL: &url.URL{Path: "/"}}
 	w := httptest.NewRecorder()
 
 	spURL := "https://sp.test"

--- a/build_request_test.go
+++ b/build_request_test.go
@@ -1,0 +1,64 @@
+package saml2
+
+import (
+	"bytes"
+	"compress/flate"
+	"encoding/base64"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedirect(t *testing.T) {
+	r := &http.Request{}
+	w := httptest.NewRecorder()
+
+	spURL := "https://sp.test"
+
+	sp := SAMLServiceProvider{
+		AssertionConsumerServiceURL: spURL,
+		AudienceURI:                 spURL,
+		IdentityProviderIssuer:      spURL,
+		IdentityProviderSSOURL:      "https://idp.test/saml/sso",
+		SignAuthnRequests:           false,
+	}
+
+	require.NoError(t, sp.AuthRedirect(w, r, "foobar"))
+	require.Len(t, w.HeaderMap, 1, "wrong number of headers was set")
+	require.Equal(t, http.StatusFound, w.Code, "wrong http status was set")
+
+	u, err := url.Parse(w.HeaderMap.Get("Location"))
+	require.NoError(t, err, "invalid url used for redirect")
+
+	require.Equal(t, "idp.test", u.Host)
+	require.Equal(t, "https", u.Scheme)
+	require.Equal(t, "foobar", u.Query().Get("RelayState"))
+
+	bs, err := base64.StdEncoding.DecodeString(u.Query().Get("SAMLRequest"))
+	require.NoError(t, err, "error base64 decoding SAMLRequest query param")
+
+	fr := flate.NewReader(bytes.NewReader(bs))
+
+	req := AuthNRequest{}
+	require.NoError(t, xml.NewDecoder(fr).Decode(&req), "Error reading/decoding from flate-compressed URL")
+
+	iss, err := url.Parse(req.Issuer)
+	require.NoError(t, err, "error parsing request issuer URL")
+
+	require.Equal(t, "sp.test", iss.Host)
+	require.WithinDuration(t, time.Now(), req.IssueInstant, time.Second, "IssueInstant was not within the expected time frame")
+
+	dst, err := url.Parse(req.Destination)
+	require.NoError(t, err, "error parsing request destination")
+	require.Equal(t, "https", dst.Scheme)
+	require.Equal(t, "idp.test", dst.Host)
+
+	//Require that the destination is the same as the redirected URL, except params
+	require.Equal(t, fmt.Sprintf("%s://%s%s", u.Scheme, u.Host, u.Path), dst.String())
+}

--- a/response.go
+++ b/response.go
@@ -24,12 +24,10 @@ type Response struct {
 
 //NewResponseFromReader returns a Response or error based on the given reader.
 func NewResponseFromReader(r io.Reader) (*Response, error) {
-	buf := &bytes.Buffer{}
-
 	var res Response
 
 	//Decode and copy bytes into buffer
-	err := xml.NewDecoder(io.TeeReader(r, buf)).Decode(&res)
+	err := xml.NewDecoder(r).Decode(&res)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This adds a small convenience method for redirecting a request to the SP's configured IDP.

Additionally, I've added the AuthNRequest type, currently only used for testing, but could definitely be useful in the future for Request decoding in a general-purpose SAML library.