### PR TITLE
Honor SignAuthnRequestsAlgorithm

### DIFF
--- a/build_request.go
+++ b/build_request.go
@@ -43,9 +43,6 @@ func (sp *SAMLServiceProvider) BuildAuthRequest() (string, error) {
 
 	if sp.SignAuthnRequests {
 		ctx := sp.SigningContext()
-		if string(sp.SignAuthnRequestsAlgorithm) != "" {
-			ctx.Algorithm = sp.SignAuthnRequestsAlgorithm
-		}
 		signed, err := ctx.SignEnveloped(authnRequest)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
We've been passing `SignAuthnRequestsAlgorithm`, when set, into `goxmldsig` to an ambiguously named `Algorithm` field. In practice `goxmldsig` was putting treating that value as a canonicalization algorithm identifier, so in recent PRs I removed that value entirely and added a new method for setting the signing algorithm.

This PR modifies gosaml2 to pass `SignAuthnRequestsAlgorithm` to the new method so it is actually used as the signing algorithm.