### PR TITLE
Make RequestedAuthnContext configurable, omit by default

### DIFF
--- a/build_request.go
+++ b/build_request.go
@@ -12,6 +12,8 @@ import (
 	"github.com/satori/go.uuid"
 )
 
+const issueInstantFormat = "2006-01-02T15:04:05Z"
+
 func (sp *SAMLServiceProvider) BuildAuthRequest() (string, error) {
 	authnRequest := &etree.Element{
 		Space: "samlp",
@@ -33,11 +35,15 @@ func (sp *SAMLServiceProvider) BuildAuthRequest() (string, error) {
 	nameIdPolicy.CreateAttr("AllowCreate", "true")
 	nameIdPolicy.CreateAttr("Format", sp.NameIdFormat)
 
-	requestedAuthnContext := authnRequest.CreateElement("samlp:RequestedAuthnContext")
-	requestedAuthnContext.CreateAttr("Comparison", "exact")
+	if sp.RequestedAuthnContext != nil {
+		requestedAuthnContext := authnRequest.CreateElement("samlp:RequestedAuthnContext")
+		requestedAuthnContext.CreateAttr("Comparison", sp.RequestedAuthnContext.Comparison)
 
-	authnContextClassRef := requestedAuthnContext.CreateElement("saml:AuthnContextClassRef")
-	authnContextClassRef.SetText("urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport")
+		for _, context := range sp.RequestedAuthnContext.Contexts {
+			authnContextClassRef := requestedAuthnContext.CreateElement("saml:AuthnContextClassRef")
+			authnContextClassRef.SetText(context)
+		}
+	}
 
 	doc := etree.NewDocument()
 

--- a/saml.go
+++ b/saml.go
@@ -6,23 +6,43 @@ import (
 	dsig "github.com/russellhaering/goxmldsig"
 )
 
-const issueInstantFormat = "2006-01-02T15:04:05Z"
-
 type SAMLServiceProvider struct {
 	IdentityProviderSSOURL      string
 	IdentityProviderIssuer      string
 	AssertionConsumerServiceURL string
 	SignAuthnRequests           bool
 	SignAuthnRequestsAlgorithm  string
-	AudienceURI                 string
-	IDPCertificateStore         dsig.X509CertificateStore
-	SPKeyStore                  dsig.X509KeyStore
-	NameIdFormat                string
-	SkipSignatureValidation     bool
-	AllowMissingAttributes      bool
-	Clock                       *dsig.Clock
-	signingContextMu            sync.RWMutex
-	signingContext              *dsig.SigningContext
+
+	// RequestedAuthnContext allows service providers to require that the identity
+	// provider use specific authentication mechanisms. Leaving this unset will
+	// permit the identity provider to choose the auth method. To maximize compatibility
+	// with identity providers it is recommended to leave this unset.
+	RequestedAuthnContext   *RequestedAuthnContext
+	AudienceURI             string
+	IDPCertificateStore     dsig.X509CertificateStore
+	SPKeyStore              dsig.X509KeyStore
+	NameIdFormat            string
+	SkipSignatureValidation bool
+	AllowMissingAttributes  bool
+	Clock                   *dsig.Clock
+	signingContextMu        sync.RWMutex
+	signingContext          *dsig.SigningContext
+}
+
+// RequestedAuthnContext controls which authentication mechanisms are requested of
+// the identity provider. It is generally sufficient to omit this and let the
+// identity provider select an authentication mechansim.
+type RequestedAuthnContext struct {
+	// The RequestedAuthnContext comparison policy to use. See the section 3.3.2.2.1
+	// of the SAML 2.0 specification for details. Constants named AuthnPolicyMatch*
+	// contain standardized values.
+	Comparison string
+
+	// Contexts will be passed as AuthnContextClassRefs. For example, to force password
+	// authentication on some identity providers, Contexts should have a value of
+	// []string{AuthnContextPasswordProtectedTransport}, and Comparison should have a
+	// value of AuthnPolicyMatchExact.
+	Contexts []string
 }
 
 func (sp *SAMLServiceProvider) SigningContext() *dsig.SigningContext {

--- a/xml_constants.go
+++ b/xml_constants.go
@@ -34,4 +34,11 @@ const (
 	NameIdFormatEmailAddress    = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
 	NameIdFormatUnspecified     = "urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified"
 	NameIdFormatX509SubjectName = "urn:oasis:names:tc:SAML:1.1:nameid-format:x509SubjectName"
+
+	AuthnContextPasswordProtectedTransport = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
+
+	AuthnPolicyMatchExact   = "exact"
+	AuthnPolicyMatchMinimum = "minimum"
+	AuthnPolicyMatchMaximum = "maximum"
+	AuthnPolicyMatchBetter  = "better"
 )


### PR DESCRIPTION
Currently every AuthnRequest includes

```xml
<samlp:RequestedAuthnContext Comparison="exact">
  <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
</samlp:RequestedAuthnContext>
```

This has worked with IdPs that I've tested with until now, but ADFS seems not to support`PasswordProtectedTransport` (at least in configurations I've seen). The most immediate solution for ADFS seems to be to use a comparison policy of "minimum", which will allow it to choose a supported authentication mechanism that it considers better than `PasswordProtectedTransport`.

In reading more, it seems like passing `RequestedAuthnContext` at all may be inadvisable in the default case, as the set of supported mechanisms and comparison semantics can vary a lot across identity providers.

This PR causes us to omit this from AuthnRequests by default but allows implementers more flexibility to choose exact configurations if they prefer.