### PR TITLE
Allow setting canonicalizer and update AuthnRequest

### DIFF
--- a/saml.go
+++ b/saml.go
@@ -14,8 +14,9 @@ type SAMLServiceProvider struct {
 	AssertionConsumerServiceURL string
 	ServiceProviderIssuer       string
 
-	SignAuthnRequests          bool
-	SignAuthnRequestsAlgorithm string
+	SignAuthnRequests              bool
+	SignAuthnRequestsAlgorithm     string
+	SignAuthnRequestsCanonicalizer dsig.Canonicalizer
 
 	// RequestedAuthnContext allows service providers to require that the identity
 	// provider use specific authentication mechanisms. Leaving this unset will
@@ -63,6 +64,10 @@ func (sp *SAMLServiceProvider) SigningContext() *dsig.SigningContext {
 
 	sp.signingContext = dsig.NewDefaultSigningContext(sp.SPKeyStore)
 	sp.signingContext.SetSignatureMethod(sp.SignAuthnRequestsAlgorithm)
+	if sp.SignAuthnRequestsCanonicalizer != nil {
+		sp.signingContext.Canonicalizer = sp.SignAuthnRequestsCanonicalizer
+	}
+
 	return sp.signingContext
 }
 


### PR DESCRIPTION
**Purpose**

At the moment Microsoft ADFS does not support C14N11 canonicalization. This PR adds support for allowing you to use a different canonicalizer in `SAMLServiceProvider`.

In addition building the `AuthnRequest` has been updated to insert the signature after the `Issuer`. This brings the generated `AuthnRequest` in line with the XSD schema and allows Microsoft AD FS to validate the request.

**Implementation**

* A new field `SignAuthnRequestsCanonicalizer` was added to `SAMLServiceProvider` that allows you to set which canonicalizer to use. If `SignAuthnRequestsCanonicalizer` is `nil`, the default canonicalizer is used.
* `SignAuthnRequest` has been updated so that it inserts the signature after the `Issuer` when building the `AuthnRequest`.

**Related PR**

https://github.com/russellhaering/goxmldsig/pull/27