### PR TITLE
Add support for metadata with multiple SingleSignOnServices

### DIFF
--- a/s2example/demo.go
+++ b/s2example/demo.go
@@ -55,7 +55,7 @@ func main() {
 	randomKeyStore := dsig.RandomKeyStoreForTest()
 
 	sp := &saml2.SAMLServiceProvider{
-		IdentityProviderSSOURL:      metadata.IDPSSODescriptor.SingleSignOnService.Location,
+		IdentityProviderSSOURL:      metadata.IDPSSODescriptor.SingleSignOnServices[0].Location,
 		IdentityProviderIssuer:      "http://example.com/saml/acs/example",
 		AssertionConsumerServiceURL: "http://localhost:8080/v1/_saml_callback",
 		SignAuthnRequests:           true,

--- a/types/metadata.go
+++ b/types/metadata.go
@@ -12,11 +12,11 @@ type EntityDescriptor struct {
 }
 
 type IDPSSODescriptor struct {
-	XMLName             xml.Name            `xml:"urn:oasis:names:tc:SAML:2.0:metadata IDPSSODescriptor"`
-	KeyDescriptors      []KeyDescriptor     `xml:"KeyDescriptor"`
-	NameIDFormats       []NameIDFormat      `xml:"NameIDFormat"`
-	SingleSignOnService SingleSignOnService `xml:"SingleSignOnService"`
-	Attributes          []Attribute         `xml:"Attribute"`
+	XMLName              xml.Name              `xml:"urn:oasis:names:tc:SAML:2.0:metadata IDPSSODescriptor"`
+	KeyDescriptors       []KeyDescriptor       `xml:"KeyDescriptor"`
+	NameIDFormats        []NameIDFormat        `xml:"NameIDFormat"`
+	SingleSignOnServices []SingleSignOnService `xml:"SingleSignOnService"`
+	Attributes           []Attribute           `xml:"Attribute"`
 }
 
 type KeyDescriptor struct {


### PR DESCRIPTION
This should fix #29 

This is a slightly breaking change but seems worth it, and I don't think we have many consumers of this metadata type.