### PR TITLE
Increase Usage of Warnings Across Response Parsing

### DIFF
--- a/decode_response.go
+++ b/decode_response.go
@@ -151,7 +151,7 @@ func (sp *SAMLServiceProvider) validateAssertionSignatures(el *etree.Element) er
 //ValidateEncodedResponse both decodes and validates, based on SP
 //configuration, an encoded, signed response. It will also appropriately
 //decrypt a response if the assertion was encrypted
-func (sp *SAMLServiceProvider) ValidateEncodedResponse(encodedResponse string) (*types.Response, error) {
+func (sp *SAMLServiceProvider) ValidateEncodedResponse(encodedResponse string, warningInfo *WarningInfo) (*types.Response, error) {
 	raw, err := base64.StdEncoding.DecodeString(encodedResponse)
 	if err != nil {
 		return nil, err
@@ -207,7 +207,7 @@ func (sp *SAMLServiceProvider) ValidateEncodedResponse(encodedResponse string) (
 		return nil, err
 	}
 
-	err = sp.Validate(decodedResponse)
+	err = sp.Validate(decodedResponse, warningInfo)
 	if err != nil {
 		return nil, err
 	}

--- a/retrieve_assertion.go
+++ b/retrieve_assertion.go
@@ -34,10 +34,11 @@ func (e ErrMissingElement) Error() string {
 //contained, or an error message if an error has been encountered.
 func (sp *SAMLServiceProvider) RetrieveAssertionInfo(encodedResponse string) (*AssertionInfo, error) {
 	assertionInfo := &AssertionInfo{
-		Values: make(Values),
+		Values:      make(Values),
+		WarningInfo: &WarningInfo{},
 	}
 
-	response, err := sp.ValidateEncodedResponse(encodedResponse)
+	response, err := sp.ValidateEncodedResponse(encodedResponse, assertionInfo.WarningInfo)
 	if err != nil {
 		return nil, ErrVerification{Cause: err}
 	}
@@ -49,7 +50,7 @@ func (sp *SAMLServiceProvider) RetrieveAssertionInfo(encodedResponse string) (*A
 
 	assertion := response.Assertions[0]
 
-	warningInfo, err := sp.VerifyAssertionConditions(&assertion)
+	err = sp.VerifyAssertionConditions(&assertion, assertionInfo.WarningInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -88,6 +89,5 @@ func (sp *SAMLServiceProvider) RetrieveAssertionInfo(encodedResponse string) (*A
 		}
 	}
 
-	assertionInfo.WarningInfo = warningInfo
 	return assertionInfo, nil
 }


### PR DESCRIPTION
As I mentioned in #31, the InvalidTime warning was being thrown in response to one NotOnOrAfter problem, and an error was being thrown in response to another one. I think those two should be consistent, and I've done a slight refactor so that they can both throw the warning.

My particular use case, and why I think they should be warnings as opposed to errors, is that I'm using the assertion itself to store session at the SP. This means that I'd like to be able to choose when to respect those NotOnOrAfter times (when I first see an assertion) and when to ignore them (when they're stored as session, so I use SessionNotOnOrAfter instead).

In general, I think the design of all SAML-aware parsing functions being able to set warnings if they need to is an improvement, since it'll make future requests similar to this one much easier to implement.

Note that this change doesn't affect the basic use case of parsing an assertion with RetrieveAssertionInfo, since a responsible user would already be checking the warning if they cared about the time.