### PR TITLE
removed IDPSSODescriptor from SP metadata

### DIFF
--- a/saml.go
+++ b/saml.go
@@ -79,7 +79,7 @@ func (sp *SAMLServiceProvider) Metadata() (*types.EntityDescriptor, error) {
 	return &types.EntityDescriptor{
 		ValidUntil: time.Now().UTC().Add(time.Hour * 24 * 7), // 7 days
 		EntityID:   sp.ServiceProviderIssuer,
-		SPSSODescriptor: types.SPSSODescriptor{
+		SPSSODescriptor: &types.SPSSODescriptor{
 			AuthnRequestsSigned:        sp.SignAuthnRequests,
 			WantAssertionsSigned:       !sp.SkipSignatureValidation,
 			ProtocolSupportEnumeration: SAMLProtocolNamespace,

--- a/types/metadata.go
+++ b/types/metadata.go
@@ -11,9 +11,9 @@ type EntityDescriptor struct {
 	XMLName    xml.Name  `xml:"urn:oasis:names:tc:SAML:2.0:metadata EntityDescriptor"`
 	ValidUntil time.Time `xml:"validUntil,attr"`
 	// SAML 2.0 8.3.6 Entity Identifier could be used to represent issuer
-	EntityID         string           `xml:"entityID,attr"`
-	SPSSODescriptor  SPSSODescriptor  `xml:"SPSSODescriptor"`
-	IDPSSODescriptor IDPSSODescriptor `xml:"IDPSSODescriptor"`
+	EntityID         string            `xml:"entityID,attr"`
+	SPSSODescriptor  *SPSSODescriptor  `xml:"SPSSODescriptor,omitempty"`
+	IDPSSODescriptor *IDPSSODescriptor `xml:"IDPSSODescriptor,omitempty"`
 }
 
 type Endpoint struct {


### PR DESCRIPTION
I'm integrating your library with ADFS and ADFS 2.0 is not able to add SP by URL because of IDPSSODescriptor that is present in SP metadata.
I replaced values with pointers in EntityDescriptor, so when SP or IDP is not needed - it is not marshaled to xml.