### PR TITLE
artifact binding support

### DIFF
--- a/artifact.go
+++ b/artifact.go
@@ -1,0 +1,98 @@
+package saml2
+
+import (
+	"bytes"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/beevik/etree"
+	"github.com/russellhaering/gosaml2/uuid"
+)
+
+func (sp *SAMLServiceProvider) ResolveArtifact(artifact string) (*AssertionInfo, error) {
+	if sp.HTTPClient == nil {
+		return nil, errors.New("HTTPClient must be set for artifact binding")
+	}
+	request, err := sp.buildResolveRequest(artifact)
+	if err != nil {
+		return nil, err
+	}
+	post, err := http.NewRequest(http.MethodPost, sp.IdentityProviderArtifactResolutionServiceURL, request)
+	if err != nil {
+		return nil, err
+	}
+	post.Header.Add("Content-Type", "text/xml")
+	post.Header.Add("SOAPAction", "http://www.oasis-open.org/committees/security")
+	resp, err := sp.HTTPClient.Do(post)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code from artifact resolve request %d", resp.StatusCode)
+	}
+	// Buffer the response and base64 encode it.
+	// It's not ideal, but existing parsing methods expect it to be encoded.
+	// Attempting to minimize change for now.
+	doc := etree.NewDocument()
+	doc.ReadFrom(resp.Body)
+	el := doc.FindElement("./Envelope/Body/ArtifactResponse/Response")
+	doc = etree.NewDocument()
+	doc.SetRoot(el)
+	var buffer bytes.Buffer
+	encoder := base64.NewEncoder(base64.StdEncoding, &buffer)
+	doc.WriteTo(encoder)
+	encoder.Close()
+	return sp.RetrieveAssertionInfo(buffer.String())
+}
+
+func (sp *SAMLServiceProvider) buildResolveRequest(artifact string) (io.Reader, error) {
+	envelope := &etree.Element{
+		Space: "soap-env",
+		Tag:   "Envelope",
+	}
+	envelope.CreateAttr("xmlns:soap-env", "http://schemas.xmlsoap.org/soap/envelope/")
+	body := envelope.CreateElement("soap-env:Body")
+	artifactResolve := &etree.Element{
+		Space: "samlp",
+		Tag:   "ArtifactResolve",
+	}
+	artifactResolve.CreateAttr("xmlns:samlp", "urn:oasis:names:tc:SAML:2.0:protocol")
+	artifactResolve.CreateAttr("xmlns:saml", "urn:oasis:names:tc:SAML:2.0:assertion")
+
+	arID := uuid.NewV4()
+	artifactResolve.CreateAttr("ID", "_"+arID.String())
+	artifactResolve.CreateAttr("Version", "2.0")
+	artifactResolve.CreateAttr("IssueInstant", sp.Clock.Now().UTC().Format(issueInstantFormat))
+
+	// NOTE(russell_h): In earlier versions we mistakenly sent the IdentityProviderIssuer
+	// in the AuthnRequest. For backwards compatibility we will fall back to that
+	// behavior when ServiceProviderIssuer isn't set.
+	if sp.ServiceProviderIssuer != "" {
+		artifactResolve.CreateElement("saml:Issuer").SetText(sp.ServiceProviderIssuer)
+	} else {
+		artifactResolve.CreateElement("saml:Issuer").SetText(sp.IdentityProviderIssuer)
+	}
+
+	artifactResolve.CreateElement("samlp:Artifact").SetText(artifact)
+
+	// TODO should really change this method name
+	signed, err := sp.SignAuthnRequest(artifactResolve)
+	if err != nil {
+		return nil, err
+	}
+
+	body.AddChild(signed)
+	doc := etree.NewDocument()
+	doc.SetRoot(envelope)
+	message, err := doc.WriteToString()
+	if err != nil {
+		return nil, err
+	}
+
+	return strings.NewReader(message), nil
+}

--- a/artifact_test.go
+++ b/artifact_test.go
@@ -1,0 +1,41 @@
+package saml2
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/beevik/etree"
+	dsig "github.com/russellhaering/goxmldsig"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArtifact(t *testing.T) {
+	spURL := "https://sp.test"
+	randomKeyStore := dsig.RandomKeyStoreForTest()
+	sp := SAMLServiceProvider{
+		AssertionConsumerServiceURL: spURL,
+		AudienceURI:                 spURL,
+		ServiceProviderIssuer:       spURL,
+		IdentityProviderSSOURL:      "https://idp.test/saml/sso",
+		SignAuthnRequests:           true,
+		SPKeyStore:                  randomKeyStore,
+	}
+	req, err := sp.buildResolveRequest("1234567")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doc := etree.NewDocument()
+	_, err = doc.ReadFrom(req)
+	require.NoError(t, err)
+
+	// Make sure request is signed
+	el := doc.FindElement("./Envelope/Body/ArtifactResolve/Signature")
+	require.NotNil(t, el)
+	// Make sure artifact is set
+	el = doc.FindElement("./Envelope/Body/ArtifactResolve/Artifact")
+	require.NotNil(t, el)
+	require.Equal(t, "1234567", el.Text())
+	io.Copy(os.Stdout, req)
+}

--- a/types/metadata.go
+++ b/types/metadata.go
@@ -40,12 +40,13 @@ type SPSSODescriptor struct {
 }
 
 type IDPSSODescriptor struct {
-	XMLName                 xml.Name              `xml:"urn:oasis:names:tc:SAML:2.0:metadata IDPSSODescriptor"`
-	WantAuthnRequestsSigned bool                  `xml:"WantAuthnRequestsSigned,attr"`
-	KeyDescriptors          []KeyDescriptor       `xml:"KeyDescriptor"`
-	NameIDFormats           []NameIDFormat        `xml:"NameIDFormat"`
-	SingleSignOnServices    []SingleSignOnService `xml:"SingleSignOnService"`
-	Attributes              []Attribute           `xml:"Attribute"`
+	XMLName                   xml.Name        `xml:"urn:oasis:names:tc:SAML:2.0:metadata IDPSSODescriptor"`
+	WantAuthnRequestsSigned   bool            `xml:"WantAuthnRequestsSigned,attr"`
+	KeyDescriptors            []KeyDescriptor `xml:"KeyDescriptor"`
+	ArtifactResolutionService IndexedEndpoint
+	NameIDFormats             []NameIDFormat        `xml:"NameIDFormat"`
+	SingleSignOnServices      []SingleSignOnService `xml:"SingleSignOnService"`
+	Attributes                []Attribute           `xml:"Attribute"`
 }
 
 type KeyDescriptor struct {

--- a/xml_constants.go
+++ b/xml_constants.go
@@ -50,6 +50,7 @@ const (
 
 	BindingHttpPost     = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST"
 	BindingHttpRedirect = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect"
+	BindingHttpArtifact = "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Artifact"
 )
 
 const (


### PR DESCRIPTION
Relates to #40

This integrates Artifact Binding support. I tried to make as few changes as possible. In my tests I was able to switch back and forth between post and artifact binding without issue. 

I did have to write a different example client because Okta seems to always respond with a post binding response regardless of the request made. I didn't include my example in the commit because it involved having a working IdP setup and probably would be of limited use to others.

 SP creation in it looks like the following:

sp := &saml2.SAMLServiceProvider{
		IdentityProviderSSOURL:                       metadata.IDPSSODescriptor.SingleSignOnServices[0].Location,
		IdentityProviderArtifactResolutionServiceURL: metadata.IDPSSODescriptor.ArtifactResolutionService.Location,
		HTTPClient:                  client,
		IdentityProviderIssuer:      metadata.EntityID,
		ServiceProviderIssuer:       "http://example.com/saml/acs/example",
		AssertionConsumerServiceURL: "http://localhost:8080/v1/_saml_callback",
		SignAuthnRequests:           true,
		AudienceURI:                 "http://example.com/saml/acs/example",
		IDPCertificateStore:         &certStore,
		SPKeyStore:                  keyStore,
		RequestedBinding:            saml2.BindingHttpArtifact,
	}

IdentityProviderArtifactResolutionServiceURL, RequestedBinding, and HTTPClient are the new fields. None are required if clients want to stick with POST binding.

On an unrelated note, I had to change BuildAuthURL to call BuildAuthURLRedirect rather than BuildAuthURLFromDocument to get valid requests for my IdP.