### PR TITLE
Optimize uuid.String

### DIFF
--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -4,7 +4,7 @@ package uuid
 
 import (
 	"crypto/rand"
-	"fmt"
+	"encoding/hex"
 )
 
 type UUID [16]byte
@@ -23,5 +23,17 @@ func NewV4() *UUID {
 }
 
 func (u *UUID) String() string {
-	return fmt.Sprintf("%x-%x-%x-%x-%x", u[:4], u[4:6], u[6:8], u[8:10], u[10:])
+	buf := make([]byte, 36)
+
+	hex.Encode(buf[0:8], u[0:4])
+	buf[8] = '-'
+	hex.Encode(buf[9:13], u[4:6])
+	buf[13] = '-'
+	hex.Encode(buf[14:18], u[6:8])
+	buf[18] = '-'
+	hex.Encode(buf[19:23], u[8:10])
+	buf[23] = '-'
+	hex.Encode(buf[24:], u[10:])
+
+	return string(buf)
 }

--- a/uuid/uuid_test.go
+++ b/uuid/uuid_test.go
@@ -17,3 +17,12 @@ func TestUUID(t *testing.T) {
 		t.Errorf("Expecting different UUIDs to be different, but they are the same.\n")
 	}
 }
+
+func TestString(t *testing.T) {
+	u := UUID{0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8}
+	s := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+	if u.String() != s {
+		t.Errorf("Expecting uuid string %q, got %q\n", s, u.String())
+	}
+}


### PR DESCRIPTION
Write hex encoded data to a buffer instead of using fmt.Sprintf.

```
name     old time/op    new time/op    delta
String-2     412ns ± 5%      68ns ±14%  -83.41%  (p=0.000 n=9+9)

name     old alloc/op   new alloc/op   delta
String-2      208B ± 0%       48B ± 0%  -76.92%  (p=0.000 n=10+10)

name     old allocs/op  new allocs/op  delta
String-2      6.00 ± 0%      1.00 ± 0%  -83.33%  (p=0.000 n=10+10)
```