### PR TITLE
add support for RSA 1.5 transport of AES keys

### DIFF
--- a/types/encrypted_key.go
+++ b/types/encrypted_key.go
@@ -41,6 +41,7 @@ type DigestMethod struct {
 const (
 	MethodRSAOAEP  = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"
 	MethodRSAOAEP2 = "http://www.w3.org/2009/xmlenc11#rsa-oaep"
+	MethodRSA1_5   = "http://www.w3.org/2001/04/xmlenc#rsa-1_5"
 )
 
 //Well-known private key encryption methods
@@ -122,6 +123,18 @@ func (ek *EncryptedKey) DecryptSymmetricKey(cert *tls.Certificate) (cipher.Block
 			return nil, fmt.Errorf("missing encryption algorithm")
 		case MethodRSAOAEP, MethodRSAOAEP2:
 			pt, err := rsa.DecryptOAEP(h, rand.Reader, pk, cipherText, nil)
+			if err != nil {
+				return nil, fmt.Errorf("rsa internal error: %v", err)
+			}
+
+			b, err := aes.NewCipher(pt)
+			if err != nil {
+				return nil, err
+			}
+
+			return b, nil
+		case MethodRSA1_5:
+			pt, err := rsa.DecryptPKCS1v15(rand.Reader, pk, cipherText)
 			if err != nil {
 				return nil, fmt.Errorf("rsa internal error: %v", err)
 			}


### PR DESCRIPTION
https://www.w3.org/TR/xmlenc-core/#sec-RSA-1_5

Slight departure from the spec, in that the spec reads:
> Implementations must support this key transport algorithm for transporting 192-bit TRIPLEDES keys. Support of this algorithm for transporting other keys is optional.

This PR _only_ implements AES key transport, not tripledes.

This version of the spec also has this passage:
> Note: Implementation of RSA v1.5 is not recommended due to security risks associated with the algorithm.

But I want to support assertions from IDPs that aren't exactly up-to-date on the current xmlenc spec.

Fixes things for me, not sure about testing this, though.