### PR TITLE
Fix compatibility with Microsoft Active Directory Federation Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ The following identity providers have been tested:
 * Shibboleth
 * Ipsilon
 * OneLogin
+* Microsoft Azure AD
+* Microsoft Active Directory Federation Services (AD FS)

--- a/retrieve_assertion.go
+++ b/retrieve_assertion.go
@@ -77,10 +77,10 @@ func (sp *SAMLServiceProvider) RetrieveAssertionInfo(encodedResponse string) (*A
 
 	nameID := subject.NameID
 	if nameID == nil {
-		return nil, ErrMissingElement{Tag: NameIdTag}
+		assertionInfo.NameID = ""
+	} else {
+		assertionInfo.NameID = nameID.Value
 	}
-
-	assertionInfo.NameID = nameID.Value
 
 	//Get the actual assertion attributes
 	attributeStatement := assertion.AttributeStatement


### PR DESCRIPTION
Microsoft's SAML implementation does not provide the NameID value within the assertion. This causes gosaml2 to not accept the assertion even though it's technically valid. 

gosaml2 did not handle this condition gracefully and prevented gosaml2 from working with AD FS and AzureAD. This patch fixes this and updates the README.md to include these tested platforms.