### PR TITLE
Some usability improvements to s2example

### DIFF
--- a/s2example/demo.go
+++ b/s2example/demo.go
@@ -129,6 +129,7 @@ func main() {
 	println(authURL)
 
 	println("Supply:")
+	fmt.Printf("      Issuer      : %s\n", sp.IdentityProviderIssuer)
 	fmt.Printf("  SP ACS URL      : %s\n", sp.AssertionConsumerServiceURL)
 
 	err = http.ListenAndServe(":8080", nil)

--- a/s2example/demo.go
+++ b/s2example/demo.go
@@ -86,23 +86,23 @@ func main() {
 	http.HandleFunc("/v1/_saml_callback", func(rw http.ResponseWriter, req *http.Request) {
 		err := req.ParseForm()
 		if err != nil {
-			rw.WriteHeader(http.StatusBadRequest)
+			http.Error(rw, "Failed to parse form: "+err.Error(), http.StatusBadRequest)
 			return
 		}
 
 		assertionInfo, err := sp.RetrieveAssertionInfo(req.FormValue("SAMLResponse"))
 		if err != nil {
-			rw.WriteHeader(http.StatusForbidden)
+			http.Error(rw, "Failed to retrieve assertion info: "+err.Error(), http.StatusForbidden)
 			return
 		}
 
 		if assertionInfo.WarningInfo.InvalidTime {
-			rw.WriteHeader(http.StatusForbidden)
+			http.Error(rw, "Invalid time", http.StatusForbidden)
 			return
 		}
 
 		if assertionInfo.WarningInfo.NotInAudience {
-			rw.WriteHeader(http.StatusForbidden)
+			http.Error(rw, "Not in audience", http.StatusForbidden)
 			return
 		}
 


### PR DESCRIPTION
Hi, thanks for great library!  I was using s2example and a couple issues arose. First, when something went wrong no error was printed (I just got a blank page). Second, the default value for "Issuer" on the Okta Test IdP login page doesn't match the value expected by s2example. This pull requests adds error messages, and prints out the expected Issuer value so you know what to enter on the Okta page.