### PR TITLE
Don't render NameIdPolicy if NameIdFormat is empty

### DIFF
--- a/build_request.go
+++ b/build_request.go
@@ -55,9 +55,11 @@ func (sp *SAMLServiceProvider) buildAuthnRequest(includeSig bool) (*etree.Docume
 		authnRequest.CreateElement("saml:Issuer").SetText(sp.IdentityProviderIssuer)
 	}
 
-	nameIdPolicy := authnRequest.CreateElement("samlp:NameIDPolicy")
-	nameIdPolicy.CreateAttr("AllowCreate", "true")
-	nameIdPolicy.CreateAttr("Format", sp.NameIdFormat)
+	if sp.NameIdFormat != "" {
+		nameIdPolicy := authnRequest.CreateElement("samlp:NameIDPolicy")
+		nameIdPolicy.CreateAttr("AllowCreate", "true")
+		nameIdPolicy.CreateAttr("Format", sp.NameIdFormat)
+	}
 
 	if sp.RequestedAuthnContext != nil {
 		requestedAuthnContext := authnRequest.CreateElement("samlp:RequestedAuthnContext")

--- a/build_request.go
+++ b/build_request.go
@@ -55,9 +55,9 @@ func (sp *SAMLServiceProvider) buildAuthnRequest(includeSig bool) (*etree.Docume
 		authnRequest.CreateElement("saml:Issuer").SetText(sp.IdentityProviderIssuer)
 	}
 
+	nameIdPolicy := authnRequest.CreateElement("samlp:NameIDPolicy")
+	nameIdPolicy.CreateAttr("AllowCreate", "true")
 	if sp.NameIdFormat != "" {
-		nameIdPolicy := authnRequest.CreateElement("samlp:NameIDPolicy")
-		nameIdPolicy.CreateAttr("AllowCreate", "true")
 		nameIdPolicy.CreateAttr("Format", sp.NameIdFormat)
 	}
 


### PR DESCRIPTION
Reason for the PR:
According to [Azure AD documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-saml-claims-customization#nameid-format) it will use NameID format passed in SAML request and use configured nameID format if NameID is not present in request.
AuthnRequest element NameIDPolicy is optional.

Allowing to remove NameIDPolicy from request will add some flexibility for users migrating from existsing configurations to Azure to integrate with existsing services.

Changes should not brake existing functionality

