### PR TITLE
Extract Format field to know NameID format in Subject of SAML response.

### DIFF
--- a/types/response.go
+++ b/types/response.go
@@ -109,6 +109,7 @@ type AuthnContextClassRef struct {
 
 type NameID struct {
 	XMLName xml.Name `xml:"urn:oasis:names:tc:SAML:2.0:assertion NameID"`
+	Format  string   `xml:"Format,attr"`
 	Value   string   `xml:",chardata"`
 }
 


### PR DESCRIPTION
Added changes to extract Format of NameID in Subject of SAML response. This will be useful to know how 
NameId field should be interpreted.
