### PR TITLE
Support multiple certs for Encryption

### DIFF
--- a/saml.go
+++ b/saml.go
@@ -54,18 +54,20 @@ type SAMLServiceProvider struct {
 	// provider use specific authentication mechanisms. Leaving this unset will
 	// permit the identity provider to choose the auth method. To maximize compatibility
 	// with identity providers it is recommended to leave this unset.
-	RequestedAuthnContext   *RequestedAuthnContext
-	AudienceURI             string
-	IDPCertificateStore     dsig.X509CertificateStore
-	SPKeyStore              dsig.X509KeyStore // Required encryption key, default signing key
-	SPSigningKeyStore       dsig.X509KeyStore // Optional signing key
-	NameIdFormat            string
-	ValidateEncryptionCert  bool
-	SkipSignatureValidation bool
-	AllowMissingAttributes  bool
-	Clock                   *dsig.Clock
-	signingContextMu        sync.RWMutex
-	signingContext          *dsig.SigningContext
+	RequestedAuthnContext     *RequestedAuthnContext
+	AudienceURI               string
+	IDPCertificateStore       dsig.X509CertificateStore
+	SPKeyStore                dsig.X509KeyStore // Required encryption key, default signing key
+	SPSigningKeyStore         dsig.X509KeyStore // Optional signing key
+	SPKeyStoreRotate          dsig.X509KeyStore // Optional additional encryption key for rotation
+	NameIdFormat              string
+	ValidateEncryptionCert    bool
+	SkipSignatureValidation   bool
+	AllowMissingAttributes    bool
+	Clock                     *dsig.Clock
+	RequireEncryptedAssertion bool
+	signingContextMu          sync.RWMutex
+	signingContext            *dsig.SigningContext
 }
 
 // RequestedAuthnContext controls which authentication mechanisms are requested of

--- a/saml_test.go
+++ b/saml_test.go
@@ -64,7 +64,7 @@ func TestDecode(t *testing.T) {
 
 	ea := response.EncryptedAssertions[0]
 
-	k, err := ea.EncryptedKey.DecryptSymmetricKey(&cert)
+	k, err := ea.EncryptedKey.DecryptSymmetricKey([]*tls.Certificate{&cert})
 	if err != nil {
 		t.Fatalf("could not get symmetric key: %v\n", err)
 	}
@@ -73,7 +73,7 @@ func TestDecode(t *testing.T) {
 		t.Fatalf("no symmetric key")
 	}
 
-	assertion, err := ea.Decrypt(&cert)
+	assertion, err := ea.Decrypt([]*tls.Certificate{&cert})
 	if err != nil {
 		t.Fatalf("error decrypting saml data: %v\n", err)
 	}

--- a/types/encrypted_assertion.go
+++ b/types/encrypted_assertion.go
@@ -1,11 +1,11 @@
 // Copyright 2016 Russell Haering et al.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,7 +30,7 @@ type EncryptedAssertion struct {
 	CipherValue      string           `xml:"EncryptedData>CipherData>CipherValue"`
 }
 
-func (ea *EncryptedAssertion) DecryptBytes(cert *tls.Certificate) ([]byte, error) {
+func (ea *EncryptedAssertion) DecryptBytes(certs []*tls.Certificate) ([]byte, error) {
 	data, err := base64.StdEncoding.DecodeString(ea.CipherValue)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func (ea *EncryptedAssertion) DecryptBytes(cert *tls.Certificate) ([]byte, error
 		// https://www.w3.org/TR/2002/REC-xmlenc-core-20021210/Overview.html#sec-Extensions-to-KeyInfo
 		ek = &ea.DetEncryptedKey
 	}
-	k, err := ek.DecryptSymmetricKey(cert)
+	k, err := ek.DecryptSymmetricKey(certs)
 	if err != nil {
 		return nil, fmt.Errorf("cannot decrypt, error retrieving private key: %s", err)
 	}
@@ -79,8 +79,8 @@ func (ea *EncryptedAssertion) DecryptBytes(cert *tls.Certificate) ([]byte, error
 }
 
 // Decrypt decrypts and unmarshals the EncryptedAssertion.
-func (ea *EncryptedAssertion) Decrypt(cert *tls.Certificate) (*Assertion, error) {
-	plaintext, err := ea.DecryptBytes(cert)
+func (ea *EncryptedAssertion) Decrypt(certs []*tls.Certificate) (*Assertion, error) {
+	plaintext, err := ea.DecryptBytes(certs)
 	if err != nil {
 		return nil, fmt.Errorf("Error decrypting assertion: %v", err)
 	}

--- a/types/encrypted_key.go
+++ b/types/encrypted_key.go
@@ -1,11 +1,11 @@
 // Copyright 2016 Russell Haering et al.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,8 +16,8 @@ package types
 import (
 	"bytes"
 	"crypto/aes"
-	"crypto/des"
 	"crypto/cipher"
+	"crypto/des"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -42,12 +42,12 @@ type EncryptedKey struct {
 
 //EncryptionMethod specifies the type of encryption that was used.
 type EncryptionMethod struct {
-	Algorithm    string       `xml:",attr,omitempty"`
-    //Digest method is present for algorithms like RSA-OAEP.
-    //See https://www.w3.org/TR/xmlenc-core1/.
-    //To convey the digest methods an entity supports, 
-    //DigestMethod in extensions element is used.
-    //See http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-metadata-algsupport.html.
+	Algorithm string `xml:",attr,omitempty"`
+	//Digest method is present for algorithms like RSA-OAEP.
+	//See https://www.w3.org/TR/xmlenc-core1/.
+	//To convey the digest methods an entity supports,
+	//DigestMethod in extensions element is used.
+	//See http://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-metadata-algsupport.html.
 	DigestMethod *DigestMethod `xml:",omitempty"`
 }
 
@@ -60,15 +60,15 @@ type DigestMethod struct {
 const (
 	MethodRSAOAEP  = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p"
 	MethodRSAOAEP2 = "http://www.w3.org/2009/xmlenc11#rsa-oaep"
-	MethodRSAv1_5 = "http://www.w3.org/2001/04/xmlenc#rsa-1_5"
+	MethodRSAv1_5  = "http://www.w3.org/2001/04/xmlenc#rsa-1_5"
 )
 
 //Well-known private key encryption methods
 const (
-	MethodAES128GCM = "http://www.w3.org/2009/xmlenc11#aes128-gcm"
-	MethodAES128CBC = "http://www.w3.org/2001/04/xmlenc#aes128-cbc"
-	MethodAES256CBC = "http://www.w3.org/2001/04/xmlenc#aes256-cbc"
-    MethodTripleDESCBC = "http://www.w3.org/2001/04/xmlenc#tripledes-cbc"
+	MethodAES128GCM    = "http://www.w3.org/2009/xmlenc11#aes128-gcm"
+	MethodAES128CBC    = "http://www.w3.org/2001/04/xmlenc#aes128-cbc"
+	MethodAES256CBC    = "http://www.w3.org/2001/04/xmlenc#aes256-cbc"
+	MethodTripleDESCBC = "http://www.w3.org/2001/04/xmlenc#tripledes-cbc"
 )
 
 //Well-known hash methods
@@ -99,9 +99,81 @@ func debugKeyFp(keyBytes []byte) string {
 }
 
 //DecryptSymmetricKey returns the private key contained in the EncryptedKey document
-func (ek *EncryptedKey) DecryptSymmetricKey(cert *tls.Certificate) (cipher.Block, error) {
-	if len(cert.Certificate) < 1 {
-		return nil, fmt.Errorf("decryption tls.Certificate has no public certs attached")
+func (ek *EncryptedKey) DecryptSymmetricKey(certs []*tls.Certificate) (cipher.Block, error) {
+
+	decryptSymmetricKey := func(cert *tls.Certificate) (cipher.Block, error) {
+
+		if len(certs[0].Certificate) < 1 {
+			return nil, fmt.Errorf("decryption tls.Certificate has no public certs attached")
+		}
+
+		cipherText, err := base64.StdEncoding.DecodeString(ek.CipherValue)
+		if err != nil {
+			return nil, err
+		}
+
+		switch pk := cert.PrivateKey.(type) {
+		case *rsa.PrivateKey:
+			var h hash.Hash
+
+			if ek.EncryptionMethod.DigestMethod == nil {
+				//if digest method is not present lets set default method to SHA1.
+				//Digest method is used by methods like RSA-OAEP.
+				h = sha1.New()
+			} else {
+				switch ek.EncryptionMethod.DigestMethod.Algorithm {
+				case "", MethodSHA1:
+					h = sha1.New() // default
+				case MethodSHA256:
+					h = sha256.New()
+				case MethodSHA512:
+					h = sha512.New()
+				default:
+					return nil, fmt.Errorf("unsupported digest algorithm: %v",
+						ek.EncryptionMethod.DigestMethod.Algorithm)
+				}
+			}
+
+			switch ek.EncryptionMethod.Algorithm {
+			case "":
+				return nil, fmt.Errorf("missing encryption algorithm")
+			case MethodRSAOAEP, MethodRSAOAEP2:
+				pt, err := rsa.DecryptOAEP(h, rand.Reader, pk, cipherText, nil)
+				if err != nil {
+					return nil, fmt.Errorf("rsa internal error: %v", err)
+				}
+
+				b, err := aes.NewCipher(pt)
+				if err != nil {
+					return nil, err
+				}
+
+				return b, nil
+			case MethodRSAv1_5:
+				pt, err := rsa.DecryptPKCS1v15(rand.Reader, pk, cipherText)
+				if err != nil {
+					return nil, fmt.Errorf("rsa internal error: %v", err)
+				}
+
+				//From https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf the xml encryption
+				//methods to be supported are from http://www.w3.org/2001/04/xmlenc#Element.
+				//https://www.w3.org/TR/2002/REC-xmlenc-core-20021210/Overview.html#Element.
+				//https://www.w3.org/TR/2002/REC-xmlenc-core-20021210/#sec-Algorithms
+				//Sec 5.4 Key Transport:
+				//The RSA v1.5 Key Transport algorithm given below are those used in conjunction with TRIPLEDES
+				//Please also see https://www.w3.org/TR/xmlenc-core/#sec-Algorithms and
+				//https://www.w3.org/TR/xmlenc-core/#rsav15note.
+				b, err := des.NewTripleDESCipher(pt)
+				if err != nil {
+					return nil, err
+				}
+
+				return b, nil
+			default:
+				return nil, fmt.Errorf("unsupported encryption algorithm: %s", ek.EncryptionMethod.Algorithm)
+			}
+		}
+		return nil, fmt.Errorf("no cipher for decoding symmetric key")
 	}
 
 	// The EncryptedKey may or may not include X509Data (certificate).
@@ -109,79 +181,34 @@ func (ek *EncryptedKey) DecryptSymmetricKey(cert *tls.Certificate) (cipher.Block
 	// - is FYI only (fail if it does not match the SP certificate)
 	// - is NOT used to decrypt CipherData
 	if ek.X509Data != "" {
-		if encCert, err := base64.StdEncoding.DecodeString(ek.X509Data); err != nil {
+		encCert, err := base64.StdEncoding.DecodeString(ek.X509Data)
+		if err != nil {
 			return nil, fmt.Errorf("error decoding EncryptedKey certificate: %v", err)
-		} else if !bytes.Equal(cert.Certificate[0], encCert) {
-			return nil, fmt.Errorf("key decryption attempted with mismatched cert, SP cert(%.11s), assertion cert(%.11s)",
-				debugKeyFp(cert.Certificate[0]), debugKeyFp(encCert))
 		}
-	}
 
-	cipherText, err := base64.StdEncoding.DecodeString(ek.CipherValue)
-	if err != nil {
+		for _, cert := range certs {
+			if bytes.Equal(cert.Certificate[0], encCert) {
+				return decryptSymmetricKey(cert)
+			}
+		}
+
+		return nil, fmt.Errorf("matching cert not found, assertion cert(%.11s)", debugKeyFp(encCert))
+
+	} else {
+
+		// X509 Data not found, try decryption with available certs
+
+		var err error
+		for _, cert := range certs {
+			var keyBlock cipher.Block
+			keyBlock, err = decryptSymmetricKey(cert)
+			if err == nil {
+				return keyBlock, err
+			}
+		}
+
+		// err should hold the last decrypt error
 		return nil, err
 	}
 
-	switch pk := cert.PrivateKey.(type) {
-	case *rsa.PrivateKey:
-		var h hash.Hash
-
-        if ek.EncryptionMethod.DigestMethod == nil {
-            //if digest method is not present lets set default method to SHA1.
-            //Digest method is used by methods like RSA-OAEP.
-            h = sha1.New()
-        } else {
-            switch ek.EncryptionMethod.DigestMethod.Algorithm {
-            case "", MethodSHA1:
-                h = sha1.New() // default
-            case MethodSHA256:
-                h = sha256.New()
-            case MethodSHA512:
-                h = sha512.New()
-            default:
-                return nil, fmt.Errorf("unsupported digest algorithm: %v",
-                    ek.EncryptionMethod.DigestMethod.Algorithm)
-            }
-        }
-
-		switch ek.EncryptionMethod.Algorithm {
-		case "":
-			return nil, fmt.Errorf("missing encryption algorithm")
-		case MethodRSAOAEP, MethodRSAOAEP2:
-			pt, err := rsa.DecryptOAEP(h, rand.Reader, pk, cipherText, nil)
-			if err != nil {
-				return nil, fmt.Errorf("rsa internal error: %v", err)
-			}
-
-			b, err := aes.NewCipher(pt)
-			if err != nil {
-				return nil, err
-			}
-
-			return b, nil
-        case MethodRSAv1_5:
-            pt, err := rsa.DecryptPKCS1v15(rand.Reader, pk, cipherText)
-            if err != nil {
-                return nil, fmt.Errorf("rsa internal error: %v", err)
-            }
-
-            //From https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf the xml encryption
-            //methods to be supported are from http://www.w3.org/2001/04/xmlenc#Element.
-            //https://www.w3.org/TR/2002/REC-xmlenc-core-20021210/Overview.html#Element.
-            //https://www.w3.org/TR/2002/REC-xmlenc-core-20021210/#sec-Algorithms
-            //Sec 5.4 Key Transport:
-            //The RSA v1.5 Key Transport algorithm given below are those used in conjunction with TRIPLEDES
-            //Please also see https://www.w3.org/TR/xmlenc-core/#sec-Algorithms and
-            //https://www.w3.org/TR/xmlenc-core/#rsav15note.
-            b, err := des.NewTripleDESCipher(pt)
-            if err != nil {
-                return nil, err
-            }
-
-            return b, nil
-		default:
-			return nil, fmt.Errorf("unsupported encryption algorithm: %s", ek.EncryptionMethod.Algorithm)
-		}
-	}
-	return nil, fmt.Errorf("no cipher for decoding symmetric key")
 }


### PR DESCRIPTION
- Allowing multiple certs to be used for assertion decryption
helps in smoothly handling cert rotation
- Added RequireEncryptedAssertion flag to SP struct to reject
assertions if not encrypted. (false by default)