### PR TITLE
Add support for NameID in Assertions and add related attributes

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -27,7 +27,15 @@ func (vals Values) Get(k string) string {
 		return ""
 	}
 	if v, ok := vals[k]; ok && len(v.Values) > 0 {
-		return string(v.Values[0].Value)
+
+		// Select a first entry and verify if a NameID is present. If it is, return
+		// its value instead.
+		entry := v.Values[0]
+		if entry.NameID != nil && entry.NameID.Value != "" {
+			return entry.NameID.Value
+		}
+
+		return v.Values[0].Value
 	}
 	return ""
 }

--- a/types/response.go
+++ b/types/response.go
@@ -111,6 +111,7 @@ type AuthnContextClassRef struct {
 type NameID struct {
 	XMLName         xml.Name `xml:"urn:oasis:names:tc:SAML:2.0:assertion NameID"`
 	Value           string   `xml:",chardata"`
+	Format          string   `xml:",attr"`
 	NameQualifier   string   `xml:",attr"`
 	SPNameQualifier string   `xml:",attr"`
 }

--- a/types/response.go
+++ b/types/response.go
@@ -109,8 +109,10 @@ type AuthnContextClassRef struct {
 }
 
 type NameID struct {
-	XMLName xml.Name `xml:"urn:oasis:names:tc:SAML:2.0:assertion NameID"`
-	Value   string   `xml:",chardata"`
+	XMLName         xml.Name `xml:"urn:oasis:names:tc:SAML:2.0:assertion NameID"`
+	Value           string   `xml:",chardata"`
+	NameQualifier   string   `xml:",attr"`
+	SPNameQualifier string   `xml:",attr"`
 }
 
 type SubjectConfirmation struct {
@@ -172,6 +174,7 @@ type AttributeValue struct {
 	XMLName xml.Name `xml:"urn:oasis:names:tc:SAML:2.0:assertion AttributeValue"`
 	Type    string   `xml:"xsi:type,attr"`
 	Value   string   `xml:",chardata"`
+	NameID  *NameID  `xml:"NameID"`
 }
 
 type AuthnStatement struct {


### PR DESCRIPTION
Hi! 

I would like to offer you some very minor changes which would offer support for custom NameID sections.

The primary change is the inclusion of a `NameID` element inside your `Attribute` type alongside a NameID `Format` (to be able to distinguish transient and persistent names), as well as `NameQualifier` and `SPNameQualifier` for relationships.

Additionally, the `Get` method of your `AssertionInfo` will now return the NameID value, if it is present.