### PR TITLE
Fix syntax in types/response.go struct tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/russellhaering/gosaml2
+module github.com/harry-uglow/gosaml2
 
 go 1.13
 

--- a/types/response.go
+++ b/types/response.go
@@ -98,12 +98,12 @@ type Subject struct {
 }
 
 type AuthnContext struct {
-	XMLName              xml.Name              `xml:urn:oasis:names:tc:SAML:2.0:assertion AuthnContext"`
+	XMLName              xml.Name              `xml:"urn:oasis:names:tc:SAML:2.0:assertion AuthnContext"`
 	AuthnContextClassRef *AuthnContextClassRef `xml:"AuthnContextClassRef"`
 }
 
 type AuthnContextClassRef struct {
-	XMLName xml.Name `xml:urn:oasis:names:tc:SAML:2.0:assertion AuthnContextClassRef"`
+	XMLName xml.Name `xml:"urn:oasis:names:tc:SAML:2.0:assertion AuthnContextClassRef"`
 	Value   string   `xml:",chardata"`
 }
 


### PR DESCRIPTION
These syntax errors meant our code wouldn't build when we imported this package into our repo which has a strict static analyzer.