### PR TITLE
Add support for the ForceAuthn and ProtocolBinding attributes

### DIFF
--- a/build_request.go
+++ b/build_request.go
@@ -41,10 +41,17 @@ func (sp *SAMLServiceProvider) buildAuthnRequest(includeSig bool) (*etree.Docume
 
 	authnRequest.CreateAttr("ID", "_"+arId.String())
 	authnRequest.CreateAttr("Version", "2.0")
-	authnRequest.CreateAttr("ProtocolBinding", "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST")
+	if len(sp.ProtocolBinding) > 0 {
+		authnRequest.CreateAttr("ProtocolBinding", sp.ProtocolBinding)
+	} else {
+		authnRequest.CreateAttr("ProtocolBinding", BindingHttpPost)
+	}
 	authnRequest.CreateAttr("AssertionConsumerServiceURL", sp.AssertionConsumerServiceURL)
 	authnRequest.CreateAttr("IssueInstant", sp.Clock.Now().UTC().Format(issueInstantFormat))
 	authnRequest.CreateAttr("Destination", sp.IdentityProviderSSOURL)
+	if sp.ForceAuthn {
+		authnRequest.CreateAttr("ForceAuthn", "true")
+	}
 
 	// NOTE(russell_h): In earlier versions we mistakenly sent the IdentityProviderIssuer
 	// in the AuthnRequest. For backwards compatibility we will fall back to that

--- a/build_request_test.go
+++ b/build_request_test.go
@@ -128,3 +128,86 @@ func TestRequestedAuthnContextIncluded(t *testing.T) {
 	require.Equal(t, el.Tag, "AuthnContextClassRef")
 	require.Equal(t, el.Text(), AuthnContextPasswordProtectedTransport)
 }
+
+func TestProtocolBindingOmitted(t *testing.T) {
+	spURL := "https://sp.test"
+	sp := SAMLServiceProvider{
+		AssertionConsumerServiceURL: spURL,
+		AudienceURI:                 spURL,
+		IdentityProviderIssuer:      spURL,
+		IdentityProviderSSOURL:      "https://idp.test/saml/sso",
+	}
+
+	request, err := sp.BuildAuthRequest()
+	require.NoError(t, err)
+
+	doc := etree.NewDocument()
+	err = doc.ReadFromString(request)
+	require.NoError(t, err)
+
+	attr := doc.Root().SelectAttrValue("ProtocolBinding", "")
+	require.Equal(t, BindingHttpPost, attr)
+}
+
+func TestProtocolBindingIncluded(t *testing.T) {
+	spURL := "https://sp.test"
+	sp := SAMLServiceProvider{
+		AssertionConsumerServiceURL: spURL,
+		AudienceURI:                 spURL,
+		IdentityProviderIssuer:      spURL,
+		IdentityProviderSSOURL:      "https://idp.test/saml/sso",
+		ProtocolBinding:             BindingHttpRedirect,
+	}
+
+	request, err := sp.BuildAuthRequest()
+	require.NoError(t, err)
+
+	doc := etree.NewDocument()
+	err = doc.ReadFromString(request)
+	require.NoError(t, err)
+
+	attr := doc.Root().SelectAttrValue("ProtocolBinding", "")
+	require.Equal(t, BindingHttpRedirect, attr)
+}
+
+func TestForceAuthnOmitted(t *testing.T) {
+	spURL := "https://sp.test"
+	sp := SAMLServiceProvider{
+		AssertionConsumerServiceURL: spURL,
+		AudienceURI:                 spURL,
+		IdentityProviderIssuer:      spURL,
+		IdentityProviderSSOURL:      "https://idp.test/saml/sso",
+	}
+
+	request, err := sp.BuildAuthRequest()
+	require.NoError(t, err)
+
+	doc := etree.NewDocument()
+	err = doc.ReadFromString(request)
+	require.NoError(t, err)
+
+	attr := doc.Root().SelectAttr("ForceAuthn")
+	require.Nil(t, attr)
+}
+
+func TestForceAuthnIncluded(t *testing.T) {
+	spURL := "https://sp.test"
+	sp := SAMLServiceProvider{
+		AssertionConsumerServiceURL: spURL,
+		AudienceURI:                 spURL,
+		IdentityProviderIssuer:      spURL,
+		IdentityProviderSSOURL:      "https://idp.test/saml/sso",
+		ForceAuthn:                  true,
+	}
+
+	request, err := sp.BuildAuthRequest()
+	require.NoError(t, err)
+
+	doc := etree.NewDocument()
+	err = doc.ReadFromString(request)
+	require.NoError(t, err)
+
+	attr := doc.Root().SelectAttr("ForceAuthn")
+	require.NotNil(t, attr)
+	require.Equal(t, "true", attr.Value)
+}

--- a/saml.go
+++ b/saml.go
@@ -43,12 +43,15 @@ type SAMLServiceProvider struct {
 	IdentityProviderIssuer     string
 
 	AssertionConsumerServiceURL string
+	ProtocolBinding             string
 	ServiceProviderSLOURL       string
 	ServiceProviderIssuer       string
 
 	SignAuthnRequests              bool
 	SignAuthnRequestsAlgorithm     string
 	SignAuthnRequestsCanonicalizer dsig.Canonicalizer
+
+	ForceAuthn bool
 
 	// RequestedAuthnContext allows service providers to require that the identity
 	// provider use specific authentication mechanisms. Leaving this unset will


### PR DESCRIPTION
This PR adds fields to the `SAMLServiceProvider` struct so a service provider can specify the protocol binding to use and whether or not to force authentication.