### PR TITLE
Add newline between copyright and package declaration

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package saml2
 
 import "github.com/russellhaering/gosaml2/types"

--- a/authn_request.go
+++ b/authn_request.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package saml2
 
 import "time"

--- a/build_logout_response.go
+++ b/build_logout_response.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package saml2
 
 import (

--- a/build_request.go
+++ b/build_request.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package saml2
 
 import (

--- a/build_request_test.go
+++ b/build_request_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package saml2
 
 import (

--- a/decode_logout_request.go
+++ b/decode_logout_request.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package saml2
 
 import (

--- a/decode_response.go
+++ b/decode_response.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package saml2
 
 import (

--- a/decode_response_test.go
+++ b/decode_response_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package saml2
 
 import (

--- a/logout_request.go
+++ b/logout_request.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package saml2
 
 import (

--- a/providertests/exercise.go
+++ b/providertests/exercise.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 // +build go1.7
 
 package providertests

--- a/providertests/exercise_go_1_6.go
+++ b/providertests/exercise_go_1_6.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 // +build !go1.7
 
 package providertests

--- a/providertests/oktadev_test.go
+++ b/providertests/oktadev_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package providertests
 
 import (

--- a/providertests/onelogin_test.go
+++ b/providertests/onelogin_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package providertests
 
 import (

--- a/providertests/pingfed_test.go
+++ b/providertests/pingfed_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package providertests
 
 import (

--- a/providertests/providers_test.go
+++ b/providertests/providers_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package providertests
 
 import (

--- a/providertests/utils.go
+++ b/providertests/utils.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package providertests
 
 import (

--- a/retrieve_assertion.go
+++ b/retrieve_assertion.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package saml2
 
 import "fmt"

--- a/s2example/demo.go
+++ b/s2example/demo.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package main
 
 import (

--- a/saml.go
+++ b/saml.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package saml2
 
 import (

--- a/saml_test.go
+++ b/saml_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package saml2
 
 import (

--- a/test_constants.go
+++ b/test_constants.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package saml2
 
 var idpCertificate = `

--- a/types/encrypted_assertion.go
+++ b/types/encrypted_assertion.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package types
 
 import (

--- a/types/encrypted_key.go
+++ b/types/encrypted_key.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package types
 
 import (

--- a/types/metadata.go
+++ b/types/metadata.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package types
 
 import (

--- a/types/response.go
+++ b/types/response.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package types
 
 import (

--- a/uuid/uuid.go
+++ b/uuid/uuid.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package uuid
 
 // relevant bits from https://github.com/abneptis/GoUUID/blob/master/uuid.go

--- a/uuid/uuid_test.go
+++ b/uuid/uuid_test.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package uuid
 
 import (

--- a/validate.go
+++ b/validate.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package saml2
 
 import (

--- a/xml_constants.go
+++ b/xml_constants.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package saml2
 
 const (


### PR DESCRIPTION
This PR adds a newline between the package declaration, build tags and the copyright header at the top of each file.

But why?

Take a look at the go doc page here: https://pkg.go.dev/github.com/russellhaering/gosaml2#section-documentation

The license header is duplicated 12 times which makes it cumbersome to navigate the docs.