### PR TITLE
Add support for AES-192-GCM and AES-256-GCM

### DIFF
--- a/saml.go
+++ b/saml.go
@@ -119,6 +119,8 @@ func (sp *SAMLServiceProvider) Metadata() (*types.EntityDescriptor, error) {
 			},
 			EncryptionMethods: []types.EncryptionMethod{
 				{Algorithm: types.MethodAES128GCM},
+				{Algorithm: types.MethodAES192GCM},
+				{Algorithm: types.MethodAES256GCM},
 				{Algorithm: types.MethodAES128CBC},
 				{Algorithm: types.MethodAES256CBC},
 			},
@@ -185,6 +187,8 @@ func (sp *SAMLServiceProvider) MetadataWithSLO(validityHours int64) (*types.Enti
 					},
 					EncryptionMethods: []types.EncryptionMethod{
 						{Algorithm: types.MethodAES128GCM, DigestMethod: nil},
+						{Algorithm: types.MethodAES192GCM, DigestMethod: nil},
+						{Algorithm: types.MethodAES256GCM, DigestMethod: nil},
 						{Algorithm: types.MethodAES128CBC, DigestMethod: nil},
 						{Algorithm: types.MethodAES256CBC, DigestMethod: nil},
 					},

--- a/types/encrypted_assertion.go
+++ b/types/encrypted_assertion.go
@@ -1,11 +1,11 @@
 // Copyright 2016 Russell Haering et al.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     https://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -50,7 +50,7 @@ func (ea *EncryptedAssertion) DecryptBytes(cert *tls.Certificate) ([]byte, error
 	}
 
 	switch ea.EncryptionMethod.Algorithm {
-	case MethodAES128GCM:
+	case MethodAES128GCM, MethodAES192GCM, MethodAES256GCM:
 		c, err := cipher.NewGCM(k)
 		if err != nil {
 			return nil, fmt.Errorf("cannot create AES-GCM: %s", err)

--- a/types/encrypted_key.go
+++ b/types/encrypted_key.go
@@ -66,6 +66,8 @@ const (
 //Well-known private key encryption methods
 const (
 	MethodAES128GCM    = "http://www.w3.org/2009/xmlenc11#aes128-gcm"
+	MethodAES192GCM    = "http://www.w3.org/2009/xmlenc11#aes192-gcm"
+	MethodAES256GCM    = "http://www.w3.org/2009/xmlenc11#aes256-gcm"
 	MethodAES128CBC    = "http://www.w3.org/2001/04/xmlenc#aes128-cbc"
 	MethodAES256CBC    = "http://www.w3.org/2001/04/xmlenc#aes256-cbc"
 	MethodTripleDESCBC = "http://www.w3.org/2001/04/xmlenc#tripledes-cbc"


### PR DESCRIPTION
We allow AES-128-GCM encryption but there are 2 additional well-known methods: [AES-192-GCM](http://www.w3.org/2009/xmlenc11#aes192-gcm) and [AES-256-GCM](http://www.w3.org/2009/xmlenc11#aes256-gcm). This change adds support for them.