### PR TITLE
Support encryption and signing keys that implement crypto.Signer

### DIFF
--- a/saml.go
+++ b/saml.go
@@ -15,6 +15,7 @@
 package saml2
 
 import (
+	"crypto"
 	"encoding/base64"
 	"sync"
 	"time"
@@ -67,13 +68,22 @@ type SAMLServiceProvider struct {
 	RequestedAuthnContext   *RequestedAuthnContext
 	AudienceURI             string
 	IDPCertificateStore     dsig.X509CertificateStore
-	SPKeyStore              dsig.X509KeyStore // Required encryption key, default signing key
-	SPSigningKeyStore       dsig.X509KeyStore // Optional signing key
 	NameIdFormat            string
 	ValidateEncryptionCert  bool
 	SkipSignatureValidation bool
 	AllowMissingAttributes  bool
 	Clock                   *dsig.Clock
+
+	// Required encryption key and default signing key.
+	// Deprecated: Use SetSPKeyStore instead of setting or reading this field.
+	SPKeyStore dsig.X509KeyStore
+
+	// Optional signing key.
+	// Deprecated: Use SetSPSigningKeyStore instead of setting or reading this field.
+	SPSigningKeyStore dsig.X509KeyStore
+
+	spKeyStoreOverride        *KeyStore // When set via SetSPKeyStore, this field is used instead of SPKeyStore
+	spSigningKeyStoreOverride *KeyStore // When set via SetSPSigningKeyStore, this field is used instead of SPSigningKeyStore
 
 	// MaximumDecompressedBodySize is the maximum size to which a compressed
 	// SAML document will be decompressed. If a compresed document is exceeds
@@ -82,6 +92,31 @@ type SAMLServiceProvider struct {
 
 	signingContextMu sync.RWMutex
 	signingContext   *dsig.SigningContext
+}
+
+// SetSPKeyStore sets the encryption key to be used.
+// It is required to either call this method (recommended) or
+// set SPKeyStore directly (deprecated).
+func (sp *SAMLServiceProvider) SetSPKeyStore(ks *KeyStore) error {
+	if ks != nil && ks.Signer == nil {
+		return ErrSaml{Message: "SP key store signer can't be nil"}
+	}
+	sp.spKeyStoreOverride = ks
+	return nil
+}
+
+// SetSPSigningKeyStore sets the signing key to be used.
+func (sp *SAMLServiceProvider) SetSPSigningKeyStore(ks *KeyStore) error {
+	if ks != nil && ks.Signer == nil {
+		return ErrSaml{Message: "SP signing key store signer can't be nil"}
+	}
+	sp.spSigningKeyStoreOverride = ks
+	return nil
+}
+
+type KeyStore struct {
+	Signer crypto.Signer
+	Cert   []byte
 }
 
 // RequestedAuthnContext controls which authentication mechanisms are requested of
@@ -118,11 +153,12 @@ func (sp *SAMLServiceProvider) Metadata() (*types.EntityDescriptor, error) {
 			},
 		})
 	}
-	if sp.GetEncryptionKey() != nil {
-		encryptionCertBytes, err := sp.GetEncryptionCertBytes()
-		if err != nil {
-			return nil, err
-		}
+
+	encryptionCertBytes, err := sp.GetEncryptionCertBytes()
+	if err != nil {
+		return nil, err
+	}
+	if encryptionCertBytes != nil {
 		keyDescriptors = append(keyDescriptors, types.KeyDescriptor{
 			Use: "encryption",
 			KeyInfo: dsigtypes.KeyInfo{
@@ -222,10 +258,12 @@ func (sp *SAMLServiceProvider) MetadataWithSLO(validityHours int64) (*types.Enti
 	}, nil
 }
 
+// Deprecated: This method won't return the correct value if SetSPKeyStore is used.
 func (sp *SAMLServiceProvider) GetEncryptionKey() dsig.X509KeyStore {
 	return sp.SPKeyStore
 }
 
+// Deprecated: This method won't return the correct value if SetSPSigningKeyStore is used.
 func (sp *SAMLServiceProvider) GetSigningKey() dsig.X509KeyStore {
 	if sp.SPSigningKeyStore == nil {
 		return sp.GetEncryptionKey() // Default is signing key is same as encryption key
@@ -233,24 +271,58 @@ func (sp *SAMLServiceProvider) GetSigningKey() dsig.X509KeyStore {
 	return sp.SPSigningKeyStore
 }
 
-func (sp *SAMLServiceProvider) GetEncryptionCertBytes() ([]byte, error) {
-	if _, encryptionCert, err := sp.GetEncryptionKey().GetKeyPair(); err != nil {
-		return nil, ErrSaml{Message: "no SP encryption certificate", System: err}
-	} else if len(encryptionCert) < 1 {
-		return nil, ErrSaml{Message: "empty SP encryption certificate"}
-	} else {
-		return encryptionCert, nil
+func (sp *SAMLServiceProvider) getEncryptionCert() ([]byte, error) {
+	if sp.spKeyStoreOverride != nil {
+		return sp.spKeyStoreOverride.Cert, nil
 	}
+	if sp.SPKeyStore != nil {
+		_, cert, err := sp.SPKeyStore.GetKeyPair()
+		return cert, err
+	}
+	return nil, nil
+}
+
+func (sp *SAMLServiceProvider) GetEncryptionCertBytes() ([]byte, error) {
+	cert, err := sp.getEncryptionCert()
+	if err != nil {
+		return nil, err
+	}
+	if len(cert) < 1 {
+		return nil, ErrSaml{Message: "empty SP encryption certificate"}
+	}
+	return cert, nil
+}
+
+func (sp *SAMLServiceProvider) getSigningCert() ([]byte, error) {
+	if sp.spSigningKeyStoreOverride != nil {
+		return sp.spSigningKeyStoreOverride.Cert, nil
+	}
+	if sp.SPSigningKeyStore != nil {
+		_, cert, err := sp.SPSigningKeyStore.GetKeyPair()
+		return cert, err
+	}
+	return sp.getEncryptionCert()
 }
 
 func (sp *SAMLServiceProvider) GetSigningCertBytes() ([]byte, error) {
-	if _, signingCert, err := sp.GetSigningKey().GetKeyPair(); err != nil {
-		return nil, ErrSaml{Message: "no SP signing certificate", System: err}
-	} else if len(signingCert) < 1 {
-		return nil, ErrSaml{Message: "empty SP signing certificate"}
-	} else {
-		return signingCert, nil
+	cert, err := sp.getSigningCert()
+	if err != nil {
+		return nil, err
 	}
+	if len(cert) < 1 {
+		return nil, ErrSaml{Message: "empty SP signing certificate"}
+	}
+	return cert, nil
+}
+
+func (sp *SAMLServiceProvider) getSignerCert() (crypto.Signer, []byte, error) {
+	if s := sp.spSigningKeyStoreOverride; s != nil {
+		return s.Signer, s.Cert, nil
+	}
+	if s := sp.SPSigningKeyStore; s != nil {
+		return s.GetKeyPair()
+	}
+	return nil, nil, nil
 }
 
 func (sp *SAMLServiceProvider) SigningContext() *dsig.SigningContext {
@@ -265,7 +337,22 @@ func (sp *SAMLServiceProvider) SigningContext() *dsig.SigningContext {
 	sp.signingContextMu.Lock()
 	defer sp.signingContextMu.Unlock()
 
-	sp.signingContext = dsig.NewDefaultSigningContext(sp.GetSigningKey())
+	signing := sp.spSigningKeyStoreOverride
+	if signing == nil {
+		signing = sp.spKeyStoreOverride
+	}
+	var err error
+	if signing != nil {
+		sp.signingContext, err = dsig.NewSigningContext(signing.Signer, [][]byte{signing.Cert})
+		if err != nil {
+			// Ideally this function should return the error, but updating the function signature would be backward incompatible.
+			// In practice, this error should never happen because NewSigningContext only errors when passed a nil signer, and
+			// sp.spSigningKeyStoreOverride only gets set after checking to ensure the signer is not nil.
+			panic(err)
+		}
+	} else {
+		sp.signingContext = dsig.NewDefaultSigningContext(sp.GetSigningKey())
+	}
 	sp.signingContext.SetSignatureMethod(sp.SignAuthnRequestsAlgorithm)
 	if sp.SignAuthnRequestsCanonicalizer != nil {
 		sp.signingContext.Canonicalizer = sp.SignAuthnRequestsCanonicalizer

--- a/saml_test.go
+++ b/saml_test.go
@@ -120,15 +120,16 @@ func signResponse(t *testing.T, resp string, sp *SAMLServiceProvider) string {
 	return str
 }
 
-func TestSAML(t *testing.T) {
+// getSAMLServiceProvider returns a SAMLServiceProvider that needs to either
+// set SPKeyStore or call Set
+func getSAMLServiceProvider(t *testing.T, _cert []byte) *SAMLServiceProvider {
+	t.Helper()
+
 	block, _ := pem.Decode([]byte(idpCertificate))
 	require.NotEmpty(t, block)
 	cert, err := x509.ParseCertificate(block.Bytes)
 	require.NoError(t, err)
 	require.NotEmpty(t, cert)
-
-	randomKeyStore := dsig.RandomKeyStoreForTest()
-	_, _cert, err := randomKeyStore.GetKeyPair()
 
 	cert0, err := x509.ParseCertificate(_cert)
 	require.NoError(t, err)
@@ -138,16 +139,46 @@ func TestSAML(t *testing.T) {
 		Roots: []*x509.Certificate{cert, cert0},
 	}
 
-	sp := &SAMLServiceProvider{
+	return &SAMLServiceProvider{
 		IdentityProviderSSOURL:      "https://dev-116807.oktapreview.com/app/scaleftdev116807_scaleft_1/exk5zt0r12Edi4rD20h7/sso/saml",
 		IdentityProviderIssuer:      "http://www.okta.com/exk5zt0r12Edi4rD20h7",
 		AssertionConsumerServiceURL: "http://localhost:8080/v1/_saml_callback",
 		SignAuthnRequests:           true,
 		AudienceURI:                 "123",
 		IDPCertificateStore:         &certStore,
-		SPKeyStore:                  randomKeyStore,
 		NameIdFormat:                NameIdFormatPersistent,
 	}
+}
+
+func TestSAML(t *testing.T) {
+	randomKeyStore := dsig.RandomKeyStoreForTest()
+	_, _cert, err := randomKeyStore.GetKeyPair()
+	if err != nil {
+		t.Fatalf("GetKeyPair failed with error: %v\n", err)
+	}
+
+	sp := getSAMLServiceProvider(t, _cert)
+	sp.SPKeyStore = randomKeyStore
+	testSAMLServiceProvider(t, sp)
+}
+
+func TestSAMLUsingSetSPKeyStore(t *testing.T) {
+	randomKeyStore := dsig.RandomKeyStoreForTest()
+	privateKey, _cert, err := randomKeyStore.GetKeyPair()
+	if err != nil {
+		t.Fatalf("GetKeyPair failed with error: %v\n", err)
+	}
+
+	sp := getSAMLServiceProvider(t, _cert)
+	sp.SetSPKeyStore(&KeyStore{
+		Cert:   _cert,
+		Signer: privateKey,
+	})
+	testSAMLServiceProvider(t, sp)
+}
+
+func testSAMLServiceProvider(t *testing.T, sp *SAMLServiceProvider) {
+	t.Helper()
 
 	authRequestURL, err := sp.BuildAuthURL("/some/link/here")
 	require.NoError(t, err)

--- a/saml_test.go
+++ b/saml_test.go
@@ -121,7 +121,7 @@ func signResponse(t *testing.T, resp string, sp *SAMLServiceProvider) string {
 }
 
 // getSAMLServiceProvider returns a SAMLServiceProvider that needs to either
-// set SPKeyStore or call Set
+// set SPKeyStore or call SetSPKeyStore.
 func getSAMLServiceProvider(t *testing.T, _cert []byte) *SAMLServiceProvider {
 	t.Helper()
 


### PR DESCRIPTION
The current implementation only supports RSA encryption and signing keys due to the `rsa.PrivateKey` type in `goxmldsig.X509KeyStore` (a downstream dependency).

In https://github.com/russellhaering/goxmldsig/pull/89, `goxmldsig` added support for using any key that implements `crypto.Signer`.

This PR uses the new goxmldsig API to add support for any key that implements `crypto.Signer`.

The implementation is backward compatible and consumers opt-in to the new code path by calling the new `SetSPKeyStore` and/or `SetSPSigningKeyStore` methods.