### PR TITLE
Add ClockLeeway and compare time on Millisecond

### DIFF
--- a/saml.go
+++ b/saml.go
@@ -72,7 +72,9 @@ type SAMLServiceProvider struct {
 	ValidateEncryptionCert  bool
 	SkipSignatureValidation bool
 	AllowMissingAttributes  bool
+
 	Clock                   *dsig.Clock
+	ClockLeeway time.Duration // to handle clock drift issues
 
 	// Required encryption key and default signing key.
 	// Deprecated: Use SetSPKeyStore instead of setting or reading this field.

--- a/validate.go
+++ b/validate.go
@@ -77,7 +77,7 @@ func (sp *SAMLServiceProvider) VerifyAssertionConditions(assertion *types.Assert
 		return nil, ErrParsing{Tag: NotBeforeAttr, Value: conditions.NotBefore, Type: "time.RFC3339"}
 	}
 
-	notBefore = notBefore.Truncate(time.Millisecond)
+	notBefore = notBefore.Add(-sp.ClockLeeway).Truncate(time.Millisecond)
 	if now.Before(notBefore) {
 		warningInfo.InvalidTime = true
 	}
@@ -91,7 +91,7 @@ func (sp *SAMLServiceProvider) VerifyAssertionConditions(assertion *types.Assert
 		return nil, ErrParsing{Tag: NotOnOrAfterAttr, Value: conditions.NotOnOrAfter, Type: "time.RFC3339"}
 	}
 
-	notOnOrAfter = notOnOrAfter.Truncate(time.Millisecond)
+	notOnOrAfter = notOnOrAfter.Add(sp.ClockLeeway).Truncate(time.Millisecond)
 	if now.After(notOnOrAfter) {
 		warningInfo.InvalidTime = true
 	}

--- a/validate.go
+++ b/validate.go
@@ -61,7 +61,7 @@ const (
 //all SAML2 contracts are upheld.
 func (sp *SAMLServiceProvider) VerifyAssertionConditions(assertion *types.Assertion) (*WarningInfo, error) {
 	warningInfo := &WarningInfo{}
-	now := sp.Clock.Now()
+	now := sp.Clock.Now().Truncate(time.Millisecond)
 
 	conditions := assertion.Conditions
 	if conditions == nil {
@@ -77,6 +77,7 @@ func (sp *SAMLServiceProvider) VerifyAssertionConditions(assertion *types.Assert
 		return nil, ErrParsing{Tag: NotBeforeAttr, Value: conditions.NotBefore, Type: "time.RFC3339"}
 	}
 
+	notBefore = notBefore.Truncate(time.Millisecond)
 	if now.Before(notBefore) {
 		warningInfo.InvalidTime = true
 	}
@@ -90,6 +91,7 @@ func (sp *SAMLServiceProvider) VerifyAssertionConditions(assertion *types.Assert
 		return nil, ErrParsing{Tag: NotOnOrAfterAttr, Value: conditions.NotOnOrAfter, Type: "time.RFC3339"}
 	}
 
+	notOnOrAfter = notOnOrAfter.Truncate(time.Millisecond)
 	if now.After(notOnOrAfter) {
 		warningInfo.InvalidTime = true
 	}


### PR DESCRIPTION
This PR addresses two time validation issues.
1. https://github.com/russellhaering/gosaml2/issues/101
2. Add a "ClockLeeway" attribute on the `SAMLServiceProvider` that can be set if you expect some clock drift. For example `sp.ClickLeeway = time.Minute`