### PR TITLE
Avoid panic when the encrypted data has wrong size for CBC

### DIFF
--- a/types/encrypted_assertion.go
+++ b/types/encrypted_assertion.go
@@ -63,6 +63,9 @@ func (ea *EncryptedAssertion) DecryptBytes(cert *tls.Certificate) ([]byte, error
 		}
 		return plainText, nil
 	case MethodAES128CBC, MethodAES256CBC, MethodTripleDESCBC:
+		if len(data)%k.BlockSize() != 0 {
+			return nil, fmt.Errorf("encrypted data is not a multiple of the expected CBC block size %d: actual size %d", k.BlockSize(), len(data))
+		}
 		nonce, data := data[:k.BlockSize()], data[k.BlockSize():]
 		c := cipher.NewCBCDecrypter(k, nonce)
 		c.CryptBlocks(data, data)


### PR DESCRIPTION
/fixes https://github.com/russellhaering/gosaml2/issues/193

A simple check to return an error in the condition that would panic `CryptBlocks`.