### PR TITLE
Use xml-exc-c14n Canonicalizer by default

### DIFF
--- a/saml.go
+++ b/saml.go
@@ -356,7 +356,10 @@ func (sp *SAMLServiceProvider) SigningContext() *dsig.SigningContext {
 	sp.signingContext.SetSignatureMethod(sp.SignAuthnRequestsAlgorithm)
 	if sp.SignAuthnRequestsCanonicalizer != nil {
 		sp.signingContext.Canonicalizer = sp.SignAuthnRequestsCanonicalizer
+	} else {
+		sp.signingContext.Canonicalizer = dsig.MakeC14N10ExclusiveCanonicalizerWithPrefixList(dsig.DefaultPrefix)
 	}
+
 
 	return sp.signingContext
 }


### PR DESCRIPTION
The [SAML Specification](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf) states the following

```
5.4.3 Canonicalization Method
SAML implementations SHOULD use Exclusive Canonicalization [Excl-C14N], with or without comments,
both in the <ds:CanonicalizationMethod> element of <ds:SignedInfo>, and as a
<ds:Transform> algorithm. Use of Exclusive Canonicalization ensures that signatures created over
SAML messages embedded in an XML context can be verified independent of that context.
```

right now, the Canonicalization used by default through the dsig library is another one ( `C14N11`).

Using this Canonicalization causes issues with some IDPs that only support Excl-C14N standard.

While the Canonicalization can be chosen through a param passed to the `SAMLServiceProvider`, it would be sensible to follow the spec by default.