### PR TITLE
Add support to allow for clock skew

### DIFF
--- a/saml.go
+++ b/saml.go
@@ -92,6 +92,8 @@ type SAMLServiceProvider struct {
 
 	signingContextMu sync.RWMutex
 	signingContext   *dsig.SigningContext
+
+	AllowClockSkew time.Duration
 }
 
 // SetSPKeyStore sets the encryption key to be used.

--- a/validate.go
+++ b/validate.go
@@ -77,7 +77,9 @@ func (sp *SAMLServiceProvider) VerifyAssertionConditions(assertion *types.Assert
 		return nil, ErrParsing{Tag: NotBeforeAttr, Value: conditions.NotBefore, Type: "time.RFC3339"}
 	}
 
-	if now.Before(notBefore) {
+	allowedSkew := sp.AllowClockSkew
+
+	if now.Before(notBefore.Add(-allowedSkew)) {
 		warningInfo.InvalidTime = true
 	}
 
@@ -90,7 +92,7 @@ func (sp *SAMLServiceProvider) VerifyAssertionConditions(assertion *types.Assert
 		return nil, ErrParsing{Tag: NotOnOrAfterAttr, Value: conditions.NotOnOrAfter, Type: "time.RFC3339"}
 	}
 
-	if now.After(notOnOrAfter) {
+	if now.After(notOnOrAfter.Add(allowedSkew)) {
 		warningInfo.InvalidTime = true
 	}
 


### PR DESCRIPTION
Hey maintainers,

we noticed an issue that with some IDPs the Saml Response might for example come in with a `notBefore` condition that is a few seconds in the future, most likely due to a slight clock skew on their side.

This change allows working with such IDPs without completely dropping time validation.