### PR TITLE
Replace html/template with manual string building

### DIFF
--- a/build_logout_response.go
+++ b/build_logout_response.go
@@ -17,7 +17,6 @@ package saml2
 import (
 	"bytes"
 	"encoding/base64"
-	"html/template"
 
 	"github.com/beevik/etree"
 	"github.com/russellhaering/gosaml2/uuid"
@@ -103,52 +102,26 @@ func (sp *SAMLServiceProvider) buildLogoutResponseBodyPostFromDocument(relayStat
 
 	encodedRespBuf := base64.StdEncoding.EncodeToString(respBuf)
 
-	var tmpl *template.Template
-	var rv bytes.Buffer
-
+	rv := new(bytes.Buffer)
+	rv.WriteString(`<html>` +
+		`<form method="post" action="`)
+	htmlEscaper.WriteString(rv, sp.IdentityProviderSLOURL)
+	rv.WriteString(`" id="SAMLResponseForm">` +
+		`<input type="hidden" name="SAMLResponse" value="`)
+	htmlEscaper.WriteString(rv, encodedRespBuf)
+	rv.WriteString(`" />`)
 	if relayState != "" {
-		tmpl = template.Must(template.New("saml-post-form").Parse(`<html>` +
-			`<form method="post" action="{{.URL}}" id="SAMLResponseForm">` +
-			`<input type="hidden" name="SAMLResponse" value="{{.SAMLResponse}}" />` +
-			`<input type="hidden" name="RelayState" value="{{.RelayState}}" />` +
-			`<input id="SAMLSubmitButton" type="submit" value="Continue" />` +
-			`</form>` +
-			`<script>document.getElementById('SAMLSubmitButton').style.visibility='hidden';</script>` +
-			`<script>document.getElementById('SAMLResponseForm').submit();</script>` +
-			`</html>`))
-		data := struct {
-			URL          string
-			SAMLResponse string
-			RelayState   string
-		}{
-			URL:          sp.IdentityProviderSLOURL,
-			SAMLResponse: encodedRespBuf,
-			RelayState:   relayState,
-		}
-		if err = tmpl.Execute(&rv, data); err != nil {
-			return nil, err
-		}
-	} else {
-		tmpl = template.Must(template.New("saml-post-form").Parse(`<html>` +
-			`<form method="post" action="{{.URL}}" id="SAMLResponseForm">` +
-			`<input type="hidden" name="SAMLResponse" value="{{.SAMLResponse}}" />` +
-			`<input id="SAMLSubmitButton" type="submit" value="Continue" />` +
-			`</form>` +
-			`<script>document.getElementById('SAMLSubmitButton').style.visibility='hidden';</script>` +
-			`<script>document.getElementById('SAMLResponseForm').submit();</script>` +
-			`</html>`))
-		data := struct {
-			URL          string
-			SAMLResponse string
-		}{
-			URL:          sp.IdentityProviderSLOURL,
-			SAMLResponse: encodedRespBuf,
-		}
-
-		if err = tmpl.Execute(&rv, data); err != nil {
-			return nil, err
-		}
+		rv.WriteString(`<input type="hidden" name="RelayState" value="`)
+		htmlEscaper.WriteString(rv, relayState)
+		rv.WriteString(`" />`)
 	}
+	rv.WriteString(`` +
+		`<input id="SAMLSubmitButton" type="submit" value="Continue" />` +
+		`</form>` +
+		`<script>document.getElementById('SAMLSubmitButton').style.visibility='hidden';</script>` +
+		`<script>document.getElementById('SAMLResponseForm').submit();</script>` +
+		`</html>`,
+	)
 
 	return rv.Bytes(), nil
 }

--- a/build_request.go
+++ b/build_request.go
@@ -19,9 +19,9 @@ import (
 	"compress/flate"
 	"encoding/base64"
 	"fmt"
-	"html/template"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/beevik/etree"
 	"github.com/russellhaering/gosaml2/uuid"
@@ -197,6 +197,18 @@ func (sp *SAMLServiceProvider) BuildAuthURLRedirect(relayState string, doc *etre
 	return sp.buildAuthURLFromDocument(relayState, BindingHttpRedirect, doc)
 }
 
+// htmlEscaper matches the escaping done in [html/template] for text and quoted
+// attributes, which is slightly more than what [html.EscapeString] does.
+var htmlEscaper = strings.NewReplacer(
+	"\x00", "\uFFFD",
+	`"`, "&#34;",
+	`&`, "&amp;",
+	`'`, "&#39;",
+	`+`, "&#43;",
+	`<`, "&lt;",
+	`>`, "&gt;",
+)
+
 func (sp *SAMLServiceProvider) buildAuthBodyPostFromDocument(relayState string, doc *etree.Document) ([]byte, error) {
 	reqBuf, err := doc.WriteToBytes()
 	if err != nil {
@@ -205,51 +217,24 @@ func (sp *SAMLServiceProvider) buildAuthBodyPostFromDocument(relayState string, 
 
 	encodedReqBuf := base64.StdEncoding.EncodeToString(reqBuf)
 
-	var tmpl *template.Template
-	var rv bytes.Buffer
-
+	rv := new(bytes.Buffer)
+	rv.WriteString(`<form method="POST" action="`)
+	htmlEscaper.WriteString(rv, sp.IdentityProviderSSOURL)
+	rv.WriteString(`" id="SAMLRequestForm">` +
+		`<input type="hidden" name="SAMLRequest" value="`)
+	htmlEscaper.WriteString(rv, encodedReqBuf)
+	rv.WriteString(`" />`)
 	if relayState != "" {
-		tmpl = template.Must(template.New("saml-post-form").Parse(`` +
-			`<form method="POST" action="{{.URL}}" id="SAMLRequestForm">` +
-			`<input type="hidden" name="SAMLRequest" value="{{.SAMLRequest}}" />` +
-			`<input type="hidden" name="RelayState" value="{{.RelayState}}" />` +
-			`<input id="SAMLSubmitButton" type="submit" value="Submit" />` +
-			`</form>` +
-			`<script>document.getElementById('SAMLSubmitButton').style.visibility="hidden";` +
-			`document.getElementById('SAMLRequestForm').submit();</script>`))
-
-		data := struct {
-			URL         string
-			SAMLRequest string
-			RelayState  string
-		}{
-			URL:         sp.IdentityProviderSSOURL,
-			SAMLRequest: encodedReqBuf,
-			RelayState:  relayState,
-		}
-		if err = tmpl.Execute(&rv, data); err != nil {
-			return nil, err
-		}
-	} else {
-		tmpl = template.Must(template.New("saml-post-form").Parse(`` +
-			`<form method="POST" action="{{.URL}}" id="SAMLRequestForm">` +
-			`<input type="hidden" name="SAMLRequest" value="{{.SAMLRequest}}" />` +
-			`<input id="SAMLSubmitButton" type="submit" value="Submit" />` +
-			`</form>` +
-			`<script>document.getElementById('SAMLSubmitButton').style.visibility="hidden";` +
-			`document.getElementById('SAMLRequestForm').submit();</script>`))
-
-		data := struct {
-			URL         string
-			SAMLRequest string
-		}{
-			URL:         sp.IdentityProviderSSOURL,
-			SAMLRequest: encodedReqBuf,
-		}
-		if err = tmpl.Execute(&rv, data); err != nil {
-			return nil, err
-		}
+		rv.WriteString(`<input type="hidden" name="RelayState" value="`)
+		htmlEscaper.WriteString(rv, relayState)
+		rv.WriteString(`" />`)
 	}
+	rv.WriteString(`` +
+		`<input id="SAMLSubmitButton" type="submit" value="Submit" />` +
+		`</form>` +
+		`<script>document.getElementById('SAMLSubmitButton').style.visibility="hidden";` +
+		`document.getElementById('SAMLRequestForm').submit();</script>`,
+	)
 
 	return rv.Bytes(), nil
 }
@@ -395,51 +380,25 @@ func (sp *SAMLServiceProvider) buildLogoutBodyPostFromDocument(relayState string
 	}
 
 	encodedReqBuf := base64.StdEncoding.EncodeToString(reqBuf)
-	var tmpl *template.Template
-	var rv bytes.Buffer
 
+	rv := new(bytes.Buffer)
+	rv.WriteString(`<form method="POST" action="`)
+	htmlEscaper.WriteString(rv, sp.IdentityProviderSLOURL)
+	rv.WriteString(`" id="SAMLRequestForm">` +
+		`<input type="hidden" name="SAMLRequest" value="`)
+	htmlEscaper.WriteString(rv, encodedReqBuf)
+	rv.WriteString(`" />`)
 	if relayState != "" {
-		tmpl = template.Must(template.New("saml-post-form").Parse(`` +
-			`<form method="POST" action="{{.URL}}" id="SAMLRequestForm">` +
-			`<input type="hidden" name="SAMLRequest" value="{{.SAMLRequest}}" />` +
-			`<input type="hidden" name="RelayState" value="{{.RelayState}}" />` +
-			`<input id="SAMLSubmitButton" type="submit" value="Submit" />` +
-			`</form>` +
-			`<script>document.getElementById('SAMLSubmitButton').style.visibility="hidden";` +
-			`document.getElementById('SAMLRequestForm').submit();</script>`))
-
-		data := struct {
-			URL         string
-			SAMLRequest string
-			RelayState  string
-		}{
-			URL:         sp.IdentityProviderSLOURL,
-			SAMLRequest: encodedReqBuf,
-			RelayState:  relayState,
-		}
-		if err = tmpl.Execute(&rv, data); err != nil {
-			return nil, err
-		}
-	} else {
-		tmpl = template.Must(template.New("saml-post-form").Parse(`` +
-			`<form method="POST" action="{{.URL}}" id="SAMLRequestForm">` +
-			`<input type="hidden" name="SAMLRequest" value="{{.SAMLRequest}}" />` +
-			`<input id="SAMLSubmitButton" type="submit" value="Submit" />` +
-			`</form>` +
-			`<script>document.getElementById('SAMLSubmitButton').style.visibility="hidden";` +
-			`document.getElementById('SAMLRequestForm').submit();</script>`))
-
-		data := struct {
-			URL         string
-			SAMLRequest string
-		}{
-			URL:         sp.IdentityProviderSLOURL,
-			SAMLRequest: encodedReqBuf,
-		}
-		if err = tmpl.Execute(&rv, data); err != nil {
-			return nil, err
-		}
+		rv.WriteString(`<input type="hidden" name="RelayState" value="`)
+		htmlEscaper.WriteString(rv, relayState)
+		rv.WriteString(`" />`)
 	}
+	rv.WriteString(`` +
+		`<input id="SAMLSubmitButton" type="submit" value="Submit" />` +
+		`</form>` +
+		`<script>document.getElementById('SAMLSubmitButton').style.visibility="hidden";` +
+		`document.getElementById('SAMLRequestForm').submit();</script>`,
+	)
 
 	return rv.Bytes(), nil
 }


### PR DESCRIPTION
This PR removes the uses of `html/template` in favor of manually building html bodies through the use of a `strings.Replacer` to do the same escaping that `html/template` would do. By getting rid of `html/template` we prevent the inhibition of Dead Code Elimination, which can have fairly massive effects on the final binary size for large binaries (see https://github.com/golang/go/issues/72895 and https://www.datadoghq.com/blog/engineering/agent-go-binaries/#unlocking-20-size-reductions-with-method-dead-code-elimination).

I think the code could be simplified a bit since we're building the same (or almost the same) body three times in the same way in different places, but in this PR I just left things as they were.