### PR TITLE
Add xmlenc namespace URI support for SHA-256 and SHA-512 digest methods

### DIFF
--- a/types/encrypted_key.go
+++ b/types/encrypted_key.go
@@ -78,6 +78,10 @@ const (
 	MethodSHA1   = "http://www.w3.org/2000/09/xmldsig#sha1"
 	MethodSHA256 = "http://www.w3.org/2000/09/xmldsig#sha256"
 	MethodSHA512 = "http://www.w3.org/2000/09/xmldsig#sha512"
+	// xmlenc namespace variants (same algorithms, different namespace per W3C RFC 9231)
+	// Note: xmlenc#sha1 is not defined in the xmlenc namespace per W3C RFC 9231
+	MethodSHA256Enc = "http://www.w3.org/2001/04/xmlenc#sha256"
+	MethodSHA512Enc = "http://www.w3.org/2001/04/xmlenc#sha512"
 )
 
 //SHA-1 is commonly used for certificate fingerprints (openssl -fingerprint and ADFS thumbprint).
@@ -136,9 +140,9 @@ func (ek *EncryptedKey) DecryptSymmetricKey(cert *tls.Certificate) (cipher.Block
 			switch ek.EncryptionMethod.DigestMethod.Algorithm {
 			case "", MethodSHA1:
 				h = sha1.New() // default
-			case MethodSHA256:
+			case MethodSHA256, MethodSHA256Enc:
 				h = sha256.New()
-			case MethodSHA512:
+			case MethodSHA512, MethodSHA512Enc:
 				h = sha512.New()
 			default:
 				return nil, fmt.Errorf("unsupported digest algorithm: %v",

--- a/types/encrypted_key_test.go
+++ b/types/encrypted_key_test.go
@@ -1,0 +1,240 @@
+// Copyright 2016 Russell Haering et al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"hash"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// testCertificate generates a test RSA key pair and certificate for testing
+func testCertificate(t *testing.T) (tls.Certificate, []byte) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().Add(365 * 24 * time.Hour), // 1 year from now
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	cert := tls.Certificate{
+		Certificate: [][]byte{certBytes},
+		PrivateKey:  key,
+	}
+
+	return cert, certBytes
+}
+
+func TestEncryptedKeyXMLNamespaceDigestMethods(t *testing.T) {
+	cert, certBytes := testCertificate(t)
+
+	testCases := []struct {
+		name           string
+		digestMethod   string
+		shouldSucceed  bool
+		description    string
+	}{
+		{
+			name:           "xmldsig SHA-256",
+			digestMethod:   MethodSHA256,
+			shouldSucceed:  true,
+			description:    "Original xmldsig namespace should work",
+		},
+		{
+			name:           "xmldsig SHA-512",
+			digestMethod:   MethodSHA512,
+			shouldSucceed:  true,
+			description:    "Original xmldsig namespace should work",
+		},
+		{
+			name:           "xmlenc SHA-256",
+			digestMethod:   MethodSHA256Enc,
+			shouldSucceed:  true,
+			description:    "xmlenc namespace variant should work (RFC 9231)",
+		},
+		{
+			name:           "xmlenc SHA-512",
+			digestMethod:   MethodSHA512Enc,
+			shouldSucceed:  true,
+			description:    "xmlenc namespace variant should work (RFC 9231)",
+		},
+		{
+			name:           "xmldsig SHA-1",
+			digestMethod:   MethodSHA1,
+			shouldSucceed:  true,
+			description:    "SHA-1 should still work for backwards compatibility",
+		},
+		{
+			name:           "unsupported digest method",
+			digestMethod:   "http://example.com/unsupported",
+			shouldSucceed:  false,
+			description:    "Unsupported methods should fail",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a minimal encrypted key with the specified digest method
+			encryptedKey := EncryptedKey{
+				X509Data: base64.StdEncoding.EncodeToString(certBytes),
+				EncryptionMethod: EncryptionMethod{
+					Algorithm: MethodRSAOAEP,
+					DigestMethod: &DigestMethod{
+						Algorithm: tc.digestMethod,
+					},
+				},
+			}
+
+			// Create dummy cipher data (we're not actually decrypting, just testing digest method handling)
+			encryptedKey.CipherValue = base64.StdEncoding.EncodeToString([]byte("dummy-cipher-data-for-testing"))
+
+			_, err := encryptedKey.DecryptSymmetricKey(&cert)
+
+			if tc.shouldSucceed {
+				// We expect this to fail at the decryption stage (not digest method stage)
+				// The important thing is it shouldn't fail with "unsupported digest algorithm"
+				if err != nil {
+					require.NotContains(t, err.Error(), "unsupported digest algorithm",
+						"%s: should not reject supported digest method - %s", tc.description, tc.digestMethod)
+				}
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "unsupported digest algorithm",
+					"%s: should reject unsupported digest method - %s", tc.description, tc.digestMethod)
+			}
+		})
+	}
+}
+
+func TestEncryptedKeyNilDigestMethod(t *testing.T) {
+	cert, certBytes := testCertificate(t)
+
+	encryptedKey := EncryptedKey{
+		X509Data: base64.StdEncoding.EncodeToString(certBytes),
+		EncryptionMethod: EncryptionMethod{
+			Algorithm:    MethodRSAOAEP,
+			DigestMethod: nil, // nil digest method should default to SHA-1
+		},
+	}
+	encryptedKey.CipherValue = base64.StdEncoding.EncodeToString([]byte("dummy-cipher-data-for-testing"))
+
+	_, err := encryptedKey.DecryptSymmetricKey(&cert)
+	// Should fail at decryption stage, not digest method stage
+	if err != nil {
+		require.NotContains(t, err.Error(), "unsupported digest algorithm",
+			"nil digest method should default to SHA-1 without error")
+	}
+}
+
+func TestEncryptedKeyEmptyStringDigestMethod(t *testing.T) {
+	cert, certBytes := testCertificate(t)
+
+	encryptedKey := EncryptedKey{
+		X509Data: base64.StdEncoding.EncodeToString(certBytes),
+		EncryptionMethod: EncryptionMethod{
+			Algorithm: MethodRSAOAEP,
+			DigestMethod: &DigestMethod{
+				Algorithm: "", // empty string should be treated as SHA-1
+			},
+		},
+	}
+	encryptedKey.CipherValue = base64.StdEncoding.EncodeToString([]byte("dummy-cipher-data-for-testing"))
+
+	_, err := encryptedKey.DecryptSymmetricKey(&cert)
+	// Should fail at decryption stage, not digest method stage
+	if err != nil {
+		require.NotContains(t, err.Error(), "unsupported digest algorithm",
+			"empty string digest method should be treated as SHA-1 without error")
+	}
+}
+
+func TestEncryptedKeyEndToEndEncryptionDecryption(t *testing.T) {
+	cert, certBytes := testCertificate(t)
+
+	// Test that the correct hash function is selected by performing actual RSA-OAEP encryption/decryption
+	testCases := []struct {
+		name         string
+		digestMethod string
+		hashFunc     func() hash.Hash
+	}{
+		{
+			name:         "xmldsig SHA-256",
+			digestMethod: MethodSHA256,
+			hashFunc:     sha256.New,
+		},
+		{
+			name:         "xmlenc SHA-256",
+			digestMethod: MethodSHA256Enc,
+			hashFunc:     sha256.New,
+		},
+		{
+			name:         "xmldsig SHA-512",
+			digestMethod: MethodSHA512,
+			hashFunc:     sha512.New,
+		},
+		{
+			name:         "xmlenc SHA-512",
+			digestMethod: MethodSHA512Enc,
+			hashFunc:     sha512.New,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Generate a random plaintext
+			plaintext := make([]byte, 32)
+			_, err := rand.Read(plaintext)
+			require.NoError(t, err)
+
+			// Encrypt using RSA-OAEP with the specified hash function
+			rsaKey := cert.PrivateKey.(*rsa.PrivateKey)
+			ciphertext, err := rsa.EncryptOAEP(tc.hashFunc(), rand.Reader, &rsaKey.PublicKey, plaintext, nil)
+			require.NoError(t, err, "encryption should succeed with hash function %s", tc.digestMethod)
+
+			// Create an encrypted key that would use the specified digest method for decryption
+			encryptedKey := EncryptedKey{
+				X509Data: base64.StdEncoding.EncodeToString(certBytes),
+				EncryptionMethod: EncryptionMethod{
+					Algorithm: MethodRSAOAEP,
+					DigestMethod: &DigestMethod{
+						Algorithm: tc.digestMethod,
+					},
+				},
+				CipherValue: base64.StdEncoding.EncodeToString(ciphertext),
+			}
+
+			// Decrypt - this should succeed because we're using the same hash function
+			block, err := encryptedKey.DecryptSymmetricKey(&cert)
+			require.NoError(t, err, "decryption should succeed with digest method %s", tc.digestMethod)
+			require.NotNil(t, block, "should return a valid cipher block")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds support for xmlenc namespace URIs for SHA-256 and SHA-512 digest methods in SAML encrypted assertion decryption. Per the W3C XML Encryption 1.1 Recommendation (Syntax and Processing), both xmldsig and xmlenc namespace URIs are valid for these digest methods.

<img width="242*3" height="450" alt="pr273-xmlenc-namespace-support" src="https://github.com/user-attachments/assets/787a677c-ef09-4c40-ad89-2e80d8c8face" />



## Problem

Some Identity Providers following XML Encryption 1.1 use the xmlenc namespace URI for digest methods:
- `http://www.w3.org/2001/04/xmlenc#sha256`
- `http://www.w3.org/2001/04/xmlenc#sha512`

Previously, gosaml2 only supported the xmldsig namespace variants:
- `http://www.w3.org/2000/09/xmldsig#sha256`
- `http://www.w3.org/2000/09/xmldsig#sha512`

This caused SAML SSO authentication to fail with the error: `unsupported digest algorithm: http://www.w3.org/2001/04/xmlenc#sha256`

## Solution

Added xmlenc namespace URI constants and updated the digest method switch statement to accept both namespace variants:

```go
const (
    MethodSHA1   = "http://www.w3.org/2000/09/xmldsig#sha1"
    MethodSHA256 = "http://www.w3.org/2000/09/xmldsig#sha256"
    MethodSHA512 = "http://www.w3.org/2000/09/xmldsig#sha512"
    // xmlenc namespace variants (same algorithms, different namespace per W3C XML Encryption 1.1)
    // Note: xmlenc#sha1 is not defined in the xmlenc namespace per W3C XML Encryption 1.1
    MethodSHA256Enc = "http://www.w3.org/2001/04/xmlenc#sha256"
    MethodSHA512Enc = "http://www.w3.org/2001/04/xmlenc#sha512"
)
```

```go
switch ek.EncryptionMethod.DigestMethod.Algorithm {
case "", MethodSHA1:
    h = sha1.New()
case MethodSHA256, MethodSHA256Enc:  // Accept both namespaces
    h = sha256.New()
case MethodSHA512, MethodSHA512Enc:  // Accept both namespaces
    h = sha512.New()
default:
    return nil, fmt.Errorf("unsupported digest algorithm: %v",
        ek.EncryptionMethod.DigestMethod.Algorithm)
}
```

## Changes

- **File**: `types/encrypted_key.go`
- **File**: `types/encrypted_key_test.go` (new)
- **Lines changed**: 246 insertions, 2 deletions
- **Impact**: Minimal, backward compatible

## Testing

Added comprehensive unit tests in `types/encrypted_key_test.go`:
- Tests both xmldsig and xmlenc namespace variants for SHA-256 and SHA-512
- Tests backwards compatibility with SHA-1
- Tests that unsupported digest methods are properly rejected
- Tests nil digest method defaults to SHA-1
- Tests empty string digest method defaults to SHA-1
- **End-to-end tests**: Actually encrypts and decrypts with RSA-OAEP to verify correct hash function selection for each namespace variant

All tests pass, confirming that both namespace URIs are correctly handled and the correct cryptographic operations are performed.

## References

- W3C XML Encryption 1.1 Recommendation: https://www.w3.org/TR/xmlenc-core1/
- Issue #272

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review of code completed
- [x] Comments added to explain the xmlenc namespace variants and xmlenc#sha1 omission
- [x] Changes are minimal and focused on the specific issue
- [x] Tests added/updated with end-to-end encryption/decryption verification
- [x] All tests pass
- [x] Addressed naming ambiguity (XML → Enc suffix)
- [x] Reduced code duplication with helper function

Closes #272