### PR TITLE
Add generic AuthNRequestProcessor and Domain Hints

### DIFF
--- a/saml.go
+++ b/saml.go
@@ -17,6 +17,7 @@ package saml2
 import (
 	"crypto"
 	"encoding/base64"
+	"github.com/beevik/etree"
 	"sync"
 	"time"
 
@@ -35,6 +36,10 @@ func (serr ErrSaml) Error() string {
 		return serr.Message
 	}
 	return "SAML error"
+}
+
+type AuthNRequestProcessor interface {
+	Process(request *etree.Element) error
 }
 
 type SAMLServiceProvider struct {
@@ -73,6 +78,8 @@ type SAMLServiceProvider struct {
 	SkipSignatureValidation bool
 	AllowMissingAttributes  bool
 	Clock                   *dsig.Clock
+
+	AuthNRequestProcessors []AuthNRequestProcessor
 
 	// Required encryption key and default signing key.
 	// Deprecated: Use SetSPKeyStore instead of setting or reading this field.


### PR DESCRIPTION
- Added a general extension mechanism (`[]AuthNRequestProcessor`), so that not every new feature needs an explicit parameter in the `SAMLServiceProvider` 
- Added `AddIdpScoping` which implements the `AuthNRequestProcessor` to provide Domain Hints to the IDP (https://docs.oasis-open.org/security/saml/v2.0backup/saml-core-2.0-os.pdf -> `3.4.1.2 Element <Scoping>`)
