### PR TITLE
Expose NameID Format attribute on parsed assertions

### DIFF
--- a/retrieve_assertion.go
+++ b/retrieve_assertion.go
@@ -82,6 +82,7 @@ func (sp *SAMLServiceProvider) RetrieveAssertionInfo(encodedResponse string) (*A
 	}
 
 	assertionInfo.NameID = nameID.Value
+	assertionInfo.NameIDFormat = nameID.Format
 
 	//Get the actual assertion attributes
 	attributeStatement := assertion.AttributeStatement

--- a/saml.go
+++ b/saml.go
@@ -384,6 +384,7 @@ type WarningInfo struct {
 
 type AssertionInfo struct {
 	NameID                     string
+	NameIDFormat               string
 	Values                     Values
 	WarningInfo                *WarningInfo
 	SessionIndex               string

--- a/saml_test.go
+++ b/saml_test.go
@@ -423,3 +423,13 @@ func TestSAMLCommentInjection(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "phoebe.simon@scaleft.com.evil.com", decodedResponse.Assertions[0].Subject.NameID.Value, "The full, canonacalized NameID should be returned.")
 }
+
+func TestNameIDFormat(t *testing.T) {
+	_, el, err := parseResponse([]byte(rawResponse), 0)
+	require.NoError(t, err)
+	decodedResponse := &types.Response{}
+	err = xmlUnmarshalElement(el, decodedResponse)
+	require.NoError(t, err)
+	require.Equal(t, "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress", decodedResponse.Assertions[0].Subject.NameID.Format)
+	require.Equal(t, "phoebe.simon@scaleft.com", decodedResponse.Assertions[0].Subject.NameID.Value)
+}

--- a/saml_test.go
+++ b/saml_test.go
@@ -240,6 +240,7 @@ func testSAMLServiceProvider(t *testing.T, sp *SAMLServiceProvider) {
 	require.Nil(t, assertionInfo.WarningInfo.ProxyRestriction)
 
 	require.Equal(t, "phoebe.simon@scaleft.com", assertionInfo.NameID)
+	require.Equal(t, "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress", assertionInfo.NameIDFormat)
 	require.Equal(t, "phoebe.simon@scaleft.com", assertionInfo.Values.Get("Email"))
 	require.Equal(t, "Phoebe", assertionInfo.Values.Get("FirstName"))
 	require.Equal(t, "Simon", assertionInfo.Values.Get("LastName"))
@@ -425,7 +426,7 @@ func TestSAMLCommentInjection(t *testing.T) {
 }
 
 func TestNameIDFormat(t *testing.T) {
-	_, el, err := parseResponse([]byte(rawResponse), 0)
+	_, el, err := parseResponse([]byte(rawResponse), 0, 0)
 	require.NoError(t, err)
 	decodedResponse := &types.Response{}
 	err = xmlUnmarshalElement(el, decodedResponse)

--- a/types/response.go
+++ b/types/response.go
@@ -110,6 +110,7 @@ type AuthnContextClassRef struct {
 
 type NameID struct {
 	XMLName xml.Name `xml:"urn:oasis:names:tc:SAML:2.0:assertion NameID"`
+	Format  string   `xml:"Format,attr,omitempty"`
 	Value   string   `xml:",chardata"`
 }
 


### PR DESCRIPTION
The SAML 2.0 NameID element carries a Format attribute (e.g. urn:oasis:names:tc:SAML:2.0:nameid-format:transient) that service providers need in order to interpret the NameID value correctly — in particular to detect transient identifiers, which are not stable across logins. Parse it into the NameID struct so callers can inspect the format actually issued by the IdP.