### PR TITLE
Avoid panics decrypting short or empty ciphertext

### DIFF
--- a/types/encrypted_assertion.go
+++ b/types/encrypted_assertion.go
@@ -56,6 +56,9 @@ func (ea *EncryptedAssertion) DecryptBytes(cert *tls.Certificate) ([]byte, error
 			return nil, fmt.Errorf("cannot create AES-GCM: %s", err)
 		}
 
+		if len(data) < c.NonceSize() {
+			return nil, fmt.Errorf("encrypted data is smaller than the AES-GCM nonce size %d: actual size %d", c.NonceSize(), len(data))
+		}
 		nonce, data := data[:c.NonceSize()], data[c.NonceSize():]
 		plainText, err := c.Open(nil, nonce, data, nil)
 		if err != nil {
@@ -65,6 +68,9 @@ func (ea *EncryptedAssertion) DecryptBytes(cert *tls.Certificate) ([]byte, error
 	case MethodAES128CBC, MethodAES256CBC, MethodTripleDESCBC:
 		if len(data)%k.BlockSize() != 0 {
 			return nil, fmt.Errorf("encrypted data is not a multiple of the expected CBC block size %d: actual size %d", k.BlockSize(), len(data))
+		}
+		if len(data) < k.BlockSize() {
+			return nil, fmt.Errorf("encrypted data is smaller than the expected CBC block size %d: actual size %d", k.BlockSize(), len(data))
 		}
 		nonce, data := data[:k.BlockSize()], data[k.BlockSize():]
 		c := cipher.NewCBCDecrypter(k, nonce)

--- a/types/encrypted_assertion_test.go
+++ b/types/encrypted_assertion_test.go
@@ -1,0 +1,115 @@
+// Copyright 2016 Russell Haering et al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"math/big"
+	"testing"
+	"time"
+)
+
+func newTestTLSCert(t *testing.T) *tls.Certificate {
+	t.Helper()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generating RSA key: %s", err)
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "gosaml2 test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("creating certificate: %s", err)
+	}
+
+	return &tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  priv,
+	}
+}
+
+// newTestEncryptedAssertion builds an EncryptedAssertion whose EncryptedKey
+// decrypts successfully against cert, so that DecryptBytes reaches the
+// symmetric decryption branch under test with cipherValue as the raw
+// (not base64-encoded) EncryptedData CipherValue.
+func newTestEncryptedAssertion(t *testing.T, cert *tls.Certificate, algorithm string, cipherValue []byte) *EncryptedAssertion {
+	t.Helper()
+
+	pub := cert.PrivateKey.(*rsa.PrivateKey).Public().(*rsa.PublicKey)
+
+	aesKey := make([]byte, 16)
+	if _, err := rand.Read(aesKey); err != nil {
+		t.Fatalf("generating AES key: %s", err)
+	}
+
+	wrappedKey, err := rsa.EncryptOAEP(sha1.New(), rand.Reader, pub, aesKey, nil)
+	if err != nil {
+		t.Fatalf("wrapping AES key: %s", err)
+	}
+
+	return &EncryptedAssertion{
+		EncryptionMethod: EncryptionMethod{Algorithm: algorithm},
+		EncryptedKey: EncryptedKey{
+			CipherValue:      base64.StdEncoding.EncodeToString(wrappedKey),
+			EncryptionMethod: EncryptionMethod{Algorithm: MethodRSAOAEP},
+		},
+		CipherValue: base64.StdEncoding.EncodeToString(cipherValue),
+	}
+}
+
+func TestDecryptBytesShortCipherTextDoesNotPanic(t *testing.T) {
+	cert := newTestTLSCert(t)
+
+	tests := []struct {
+		name        string
+		algorithm   string
+		cipherValue []byte
+	}{
+		{"GCM empty", MethodAES128GCM, []byte{}},
+		{"GCM shorter than nonce", MethodAES128GCM, []byte{0x01, 0x02, 0x03}},
+		{"CBC empty", MethodAES128CBC, []byte{}},
+		{"CBC shorter than block size", MethodAES128CBC, []byte{0x01, 0x02, 0x03}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ea := newTestEncryptedAssertion(t, cert, tt.algorithm, tt.cipherValue)
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("DecryptBytes panicked: %v", r)
+				}
+			}()
+
+			_, err := ea.DecryptBytes(cert)
+			if err == nil {
+				t.Fatalf("expected an error, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Defects

`(*EncryptedAssertion).DecryptBytes` in `types/encrypted_assertion.go` sliced attacker-controlled ciphertext without checking its length first, in two places:

1. **AES-GCM branch**: `nonce, data := data[:c.NonceSize()], data[c.NonceSize():]` had no bounds check before the slice. Short or empty ciphertext panics with `runtime error: slice bounds out of range [:12] with capacity 0`.

2. **CBC/3DES branch**: the existing guard, `if len(data)%k.BlockSize() != 0`, does not catch empty input, since `0 % 16 == 0`. Empty ciphertext falls through to `nonce, data := data[:k.BlockSize()], data[k.BlockSize():]` and panics with `runtime error: slice bounds out of range [:16] with capacity 0`.

Both are reachable pre-authentication: on the unsigned-`Response` path, `decryptAssertions` runs at `decode_response.go:388` before any signature validation, so a crafted `EncryptedAssertion` with truncated `CipherValue` can crash the process before we've established the message actually came from the IdP. There's no `recover()` anywhere in the codebase, so for non-HTTP-server callers this is a full process crash, not just a failed request.

## Fix

Added explicit length checks before both slices:
- GCM: `len(data) < c.NonceSize()` returns an error instead of slicing.
- CBC: `len(data) < k.BlockSize()` returns an error instead of slicing (kept the existing modulo check, since it catches a different malformation — sizes that are non-empty but not block-aligned).

I read through the rest of `DecryptBytes` looking for other unguarded indexing on attacker-controlled data; the padding-length indexing (`data[len(data)-1]`) is already bounds-checked from a prior hardening pass, and didn't find anything else.

## Tests

Added `types/encrypted_assertion_test.go` with a table-driven test that builds a real `EncryptedAssertion` (valid RSA-OAEP-wrapped key, so `DecryptBytes` reaches the vulnerable branch) with empty/short `CipherValue` for both GCM and CBC, asserting an error is returned rather than a panic.

Verified the test actually catches the bug: stashed the source fix (keeping the test) and reran — the GCM-empty, GCM-short, and CBC-empty cases panicked with exactly the messages above (`slice bounds out of range [:12] with capacity 0` / `[:16] with capacity 0`); the CBC-short-but-nonzero case still passed since the pre-existing modulo check already handles it. Restored the fix and reran; all pass.

`go build ./...` and `go test ./...` pass. `go vet ./...` has the same pre-existing finding at `providertests/utils.go:154` that exists on `main` (unrelated lock-copy issue) — no new vet findings from this change.
