### PR TITLE
Reject unsigned LogoutResponse when signature validation is enabled

### DIFF
--- a/decode_logout_response_test.go
+++ b/decode_logout_response_test.go
@@ -1,0 +1,47 @@
+// Copyright 2016 Russell Haering et al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package saml2
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	dsig "github.com/russellhaering/goxmldsig"
+	"github.com/stretchr/testify/require"
+)
+
+const unsignedLogoutResponseXML = `<samlp:LogoutResponse xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="_a1b2c3" Version="2.0" IssueInstant="2020-01-01T00:00:00Z" Destination="https://sp.example.com/slo" InResponseTo="_req123">
+  <saml:Issuer>https://idp.example.com</saml:Issuer>
+  <samlp:Status>
+    <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+  </samlp:Status>
+</samlp:LogoutResponse>`
+
+func TestValidateEncodedLogoutResponsePOSTRejectsUnsigned(t *testing.T) {
+	sp := &SAMLServiceProvider{
+		ServiceProviderSLOURL:  "https://sp.example.com/slo",
+		IdentityProviderIssuer: "https://idp.example.com",
+		IDPCertificateStore:    &dsig.MemoryX509CertificateStore{},
+		Clock:                  dsig.NewFakeClock(clockwork.NewFakeClockAt(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))),
+	}
+
+	encoded := base64.StdEncoding.EncodeToString([]byte(unsignedLogoutResponseXML))
+
+	_, err := sp.ValidateEncodedLogoutResponsePOST(encoded)
+	require.Error(t, err)
+	require.Equal(t, "logout response is not signed", err.Error())
+}

--- a/decode_response.go
+++ b/decode_response.go
@@ -547,7 +547,7 @@ func (sp *SAMLServiceProvider) ValidateEncodedLogoutResponsePOST(encodedResponse
 	}
 
 	// Parse the raw response
-	doc, el, err := parseResponse(raw, sp.MaximumDecompressedBodySize)
+	_, el, err := parseResponse(raw, sp.MaximumDecompressedBodySize)
 	if err != nil {
 		return nil, err
 	}
@@ -556,8 +556,7 @@ func (sp *SAMLServiceProvider) ValidateEncodedLogoutResponsePOST(encodedResponse
 	if !sp.SkipSignatureValidation {
 		el, err = sp.validateElementSignature(el)
 		if err == dsig.ErrMissingSignature {
-			// Unfortunately we just blew away our Response
-			el = doc.Root()
+			return nil, fmt.Errorf("logout response is not signed")
 		} else if err != nil {
 			return nil, err
 		} else if el == nil {


### PR DESCRIPTION
## Summary

`ValidateEncodedLogoutResponsePOST` accepted a `LogoutResponse` carrying no `<ds:Signature>` at all, even when `SkipSignatureValidation` was `false`. When `validateElementSignature` returned `dsig.ErrMissingSignature`, the code fell through, unmarshalled the untrusted element, and set `SignatureValidated = false` — but `ValidateDecodedLogoutResponse` never checks that flag, so a completely unsigned logout response was accepted as valid.

This was reported independently by two researchers. It mirrors the same class of bug already fixed on the request side in 7159bbe ("Reject unsigned LogoutRequest when signature validation is enabled"), which this change follows in approach and error style.

I also audited every other `dsig.ErrMissingSignature` handling site in the repo:
- `decode_logout_request.go` (`ValidateEncodedLogoutRequestPOST`) — already fixed by 7159bbe.
- `decode_response.go` (`validateAssertionSignatures`, `verifyAssertionSignaturesIfPresent`, and the assertion-level fallback in `ValidateEncodedResponse`) — these require at least one individually-signed assertion before accepting anything, so an entirely unsigned Response with no signed assertions is still rejected. No change needed there.

## Test plan

- Added `TestValidateEncodedLogoutResponsePOSTRejectsUnsigned`, which submits an unsigned `LogoutResponse` with `SkipSignatureValidation` unset (false) and asserts it is rejected.
- Verified the new test fails without the fix (stashed the `decode_response.go` change and reran — it failed with "An error is expected but got nil", confirming the unsigned response was previously accepted) and passes with it.
- `go build ./...` and `go test ./...` pass.
- `go vet ./...` has a pre-existing, unrelated failure at `providertests/utils.go:154`; no new vet findings introduced.
