### PR TITLE
Bound XML token count independent of decompressed byte size

### DIFF
--- a/decode_logout_request.go
+++ b/decode_logout_request.go
@@ -49,7 +49,7 @@ func (sp *SAMLServiceProvider) ValidateEncodedLogoutRequestPOST(encodedRequest s
 	}
 
 	// Parse the raw request - parseResponse is generic
-	_, el, err := parseResponse(raw, sp.MaximumDecompressedBodySize)
+	_, el, err := parseResponse(raw, sp.MaximumDecompressedBodySize, sp.MaximumXMLTokens)
 	if err != nil {
 		return nil, err
 	}

--- a/decode_response.go
+++ b/decode_response.go
@@ -34,6 +34,7 @@ import (
 
 const (
 	defaultMaxDecompressedResponseSize = 5 * 1024 * 1024
+	defaultMaxXMLTokens                = 50000
 )
 
 func (sp *SAMLServiceProvider) validationContext() *dsig.ValidationContext {
@@ -178,7 +179,7 @@ func (sp *SAMLServiceProvider) decryptAssertions(el *etree.Element) error {
 			return fmt.Errorf("unable to decrypt encrypted assertion: %v", derr)
 		}
 
-		doc, _, err := parseResponse(raw, sp.MaximumDecompressedBodySize)
+		doc, _, err := parseResponse(raw, sp.MaximumDecompressedBodySize, sp.MaximumXMLTokens)
 		if err != nil {
 			return fmt.Errorf("unable to create element from decrypted assertion bytes: %v", err)
 		}
@@ -298,7 +299,7 @@ func (sp *SAMLServiceProvider) ValidateEncodedResponse(encodedResponse string) (
 	}
 
 	// Parse the raw response
-	doc, unverifiedResponse, err := parseResponse(raw, sp.MaximumDecompressedBodySize)
+	doc, unverifiedResponse, err := parseResponse(raw, sp.MaximumDecompressedBodySize, sp.MaximumXMLTokens)
 	if err != nil {
 		return nil, err
 	}
@@ -454,6 +455,10 @@ func DecodeUnverifiedBaseResponse(encodedResponse string) (*types.UnverifiedBase
 	var response *types.UnverifiedBaseResponse
 
 	err = maybeDeflate(raw, defaultMaxDecompressedResponseSize, func(maybeXML []byte) error {
+		if bound := 3*int64(bytes.Count(maybeXML, []byte("<"))) + 1; bound > defaultMaxXMLTokens {
+			return fmt.Errorf("document contains too many XML tokens: upper bound %d exceeds maximum of %d", bound, defaultMaxXMLTokens)
+		}
+
 		response = &types.UnverifiedBaseResponse{}
 		return xml.Unmarshal(maybeXML, response)
 	})
@@ -493,11 +498,19 @@ func maybeDeflate(data []byte, maxSize int64, decoder func([]byte) error) error 
 }
 
 // parseResponse is a helper function that was refactored out so that the XML parsing behavior can be isolated and unit tested
-func parseResponse(xml []byte, maxSize int64) (*etree.Document, *etree.Element, error) {
+func parseResponse(xml []byte, maxSize int64, maxTokens int64) (*etree.Document, *etree.Element, error) {
 	var doc *etree.Document
 	var rawXML []byte
 
+	if maxTokens == 0 {
+		maxTokens = defaultMaxXMLTokens
+	}
+
 	err := maybeDeflate(xml, maxSize, func(xml []byte) error {
+		if bound := 3*int64(bytes.Count(xml, []byte("<"))) + 1; bound > maxTokens {
+			return fmt.Errorf("document contains too many XML tokens: upper bound %d exceeds maximum of %d", bound, maxTokens)
+		}
+
 		doc = etree.NewDocument()
 		rawXML = xml
 		return doc.ReadFromBytes(xml)
@@ -530,6 +543,10 @@ func DecodeUnverifiedLogoutResponse(encodedResponse string) (*types.LogoutRespon
 	var response *types.LogoutResponse
 
 	err = maybeDeflate(raw, defaultMaxDecompressedResponseSize, func(maybeXML []byte) error {
+		if bound := 3*int64(bytes.Count(maybeXML, []byte("<"))) + 1; bound > defaultMaxXMLTokens {
+			return fmt.Errorf("document contains too many XML tokens: upper bound %d exceeds maximum of %d", bound, defaultMaxXMLTokens)
+		}
+
 		response = &types.LogoutResponse{}
 		return xml.Unmarshal(maybeXML, response)
 	})
@@ -547,7 +564,7 @@ func (sp *SAMLServiceProvider) ValidateEncodedLogoutResponsePOST(encodedResponse
 	}
 
 	// Parse the raw response
-	_, el, err := parseResponse(raw, sp.MaximumDecompressedBodySize)
+	_, el, err := parseResponse(raw, sp.MaximumDecompressedBodySize, sp.MaximumXMLTokens)
 	if err != nil {
 		return nil, err
 	}

--- a/decode_response_test.go
+++ b/decode_response_test.go
@@ -16,11 +16,13 @@ package saml2
 
 import (
 	"bytes"
+	"compress/flate"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
 	"io/ioutil"
+	"strings"
 	"testing"
 	"time"
 
@@ -169,7 +171,7 @@ func TestDecodeColonsInLocalNames(t *testing.T) {
 		t.Skip()
 	}
 
-	_, _, err := parseResponse([]byte(`<x::Root/>`), 0)
+	_, _, err := parseResponse([]byte(`<x::Root/>`), 0, 0)
 	require.Error(t, err)
 }
 
@@ -180,7 +182,7 @@ func TestDecodeDoubleColonInjectionAttackResponse(t *testing.T) {
 		t.Skip()
 	}
 
-	_, _, err := parseResponse([]byte(doubleColonAssertionInjectionAttackResponse), 0)
+	_, _, err := parseResponse([]byte(doubleColonAssertionInjectionAttackResponse), 0, 0)
 	require.Error(t, err)
 }
 
@@ -226,4 +228,62 @@ func TestCompressionBombInput(t *testing.T) {
 
 	_, err = sp.RetrieveAssertionInfo(string(bs))
 	require.Error(t, err, "error validating response: deflated response exceeds maximum size of 2048 bytes")
+}
+
+// tokenBombXML builds a small, well-formed document consisting of n
+// interleaved character-data runs and self-closing elements, which is the
+// pattern that maximizes XML token count relative to byte size.
+func tokenBombXML(n int) string {
+	var b strings.Builder
+	b.WriteString("<Root>")
+	for i := 0; i < n; i++ {
+		b.WriteString("x<a/>")
+	}
+	b.WriteString("</Root>")
+	return b.String()
+}
+
+func deflateBytes(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	fw, err := flate.NewWriter(&buf, flate.DefaultCompression)
+	require.NoError(t, err)
+	_, err = fw.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, fw.Close())
+	return buf.Bytes()
+}
+
+func TestParseResponseTokenLimitRejectsTokenBomb(t *testing.T) {
+	// 20000 repetitions puts the token upper bound well above the default
+	// of 50000, while the deflated payload itself is tiny.
+	compressed := deflateBytes(t, []byte(tokenBombXML(20000)))
+
+	_, _, err := parseResponse(compressed, 0, 0)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many XML tokens")
+}
+
+func TestParseResponseTokenLimitAllowsSmallDocument(t *testing.T) {
+	compressed := deflateBytes(t, []byte(tokenBombXML(10)))
+
+	doc, el, err := parseResponse(compressed, 0, 0)
+	require.NoError(t, err)
+	require.NotNil(t, doc)
+	require.NotNil(t, el)
+}
+
+func TestParseResponseTokenLimitHonoursExplicitValue(t *testing.T) {
+	// This document's token upper bound comfortably fits under the default
+	// of 50000, but is rejected once a much smaller explicit limit is set.
+	compressed := deflateBytes(t, []byte(tokenBombXML(10)))
+
+	_, _, err := parseResponse(compressed, 0, 10)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too many XML tokens")
+
+	// A zero value falls back to the default, under which the same document
+	// parses successfully.
+	_, _, err = parseResponse(compressed, 0, 0)
+	require.NoError(t, err)
 }

--- a/saml.go
+++ b/saml.go
@@ -90,6 +90,12 @@ type SAMLServiceProvider struct {
 	// this size during decompression an error will be returned.
 	MaximumDecompressedBodySize int64
 
+	// MaximumXMLTokens bounds the number of XML tokens allowed in a decoded
+	// document. If 0, a default of 50000 is used. IdPs that emit very large
+	// attribute lists (e.g. group memberships with thousands of values) may
+	// need to raise this.
+	MaximumXMLTokens int64
+
 	signingContextMu sync.RWMutex
 	signingContext   *dsig.SigningContext
 }

--- a/saml_test.go
+++ b/saml_test.go
@@ -416,7 +416,7 @@ func TestSAMLCommentInjection(t *testing.T) {
 	*/
 
 	// To show that we are not vulnerable, we want to prove that we get the canonicalized value using our parser
-	_, el, err := parseResponse([]byte(commentInjectionAttackResponse), 0)
+	_, el, err := parseResponse([]byte(commentInjectionAttackResponse), 0, 0)
 	require.NoError(t, err)
 	decodedResponse := &types.Response{}
 	err = xmlUnmarshalElement(el, decodedResponse)


### PR DESCRIPTION
## Problem

`parseResponse` builds an etree DOM and then runs the response through `rtvalidator.Validate` (from `github.com/mattermost/xml-roundtrip-validator`), which guards against known encoding/xml parsing quirks. That validator allocates a fresh `bytes.Buffer`, `xml.NewEncoder`, and `xml.NewDecoder` per token, independent of how large or small the token is.

`MaximumDecompressedBodySize` only bounds the number of decompressed *bytes*. It says nothing about token density. A DEFLATE-compressed document consisting of many tiny elements (e.g. `x<a/>x<a/>...`) can turn a few KB on the wire into a document that decompresses to well under the byte ceiling but contains an enormous number of tokens. Measured: a 784-byte request produced 1.33 GB of allocation and 4.4M allocations in 216ms, at one tenth of a scale an attacker could reach in a single request. The same flat structure also inflates the etree DOM itself (~340MB at that scale), so the byte-size guard doesn't help there either.

## Fix

Add `MaximumXMLTokens` (default 50000) and enforce it with a cheap, allocation-free check before any parsing happens: `3*bytes.Count(xml, []byte("<")) + 1` is a proven upper bound on the number of XML tokens the standard decoder would emit. Every markup token consumes a `<`; the implicit `EndElement` from a self-closing tag consumes none but is always paired with a preceding `<`; and character-data runs are separated by `<`, so there are at most (markup tokens)+1 of them. The worst case is exactly 3 tokens per `<`, achieved by the `x<a/>x<a/>...` pattern above — a factor of 2 would under-count and isn't safe to use here. Over-counting (e.g. literal `<` inside CDATA or attribute values) only makes rejection more likely, which is fine.

The check is the first statement inside the closure passed to `maybeDeflate` in `parseResponse`, i.e. before `doc.ReadFromBytes`, so it bounds both the DOM construction and the round-trip validator with a single guard.

`parseResponse` now takes a `maxTokens int64` parameter; all call sites were updated to pass `sp.MaximumXMLTokens` (or `0` in tests, which selects the default).

The two `DecodeUnverified*` free functions (`DecodeUnverifiedBaseResponse`, `DecodeUnverifiedLogoutResponse`) call `maybeDeflate` directly and use `xml.Unmarshal` rather than the round-trip validator, so they don't suffer the same per-token allocation amplification — they're materially lower severity. Since it was clean to do, the same guard was added there too (using the default constant, since these are free functions with no `SAMLServiceProvider` to read a configured value from).

### Default of 50000

The largest real IdP fixture in this repo's test data is about 170 tokens. Some IdPs emit very large attribute/group-membership lists that can run into the low thousands of tokens. 50000 leaves generous headroom above that while still capping worst-case allocation at a small, bounded amount of work.

### Note on error messages

`maybeDeflate` tries the decoder against the raw input first and only attempts inflation if that fails. For an *uncompressed* token bomb, the token-count check fails during the raw attempt, `maybeDeflate` then tries (and fails) to inflate non-deflated data, and the inflate error is what's ultimately returned rather than the token-count error. The document is still rejected correctly — only the surfaced error text differs. For the actual attack shape (compressed), the token-count error surfaces cleanly. Left as-is; the new tests target the compressed path to get a precise error.

## Testing

- `TestParseResponseTokenLimitRejectsTokenBomb` — a compressed, token-dense document exceeding the default limit is rejected.
- `TestParseResponseTokenLimitAllowsSmallDocument` — a compressed document under the limit still parses.
- `TestParseResponseTokenLimitHonoursExplicitValue` — an explicit small `maxTokens` rejects a document that fits under the default, and `0` falls back to the default.

Verified the rejection tests fail without the guard (temporarily removed the check in `parseResponse`, reran — both rejection-based tests failed with "expected error, got nil" — then restored it).

`go build ./...` and `go test ./...` pass, including all ~95 real provider-response fixtures under `providertests/testdata/` and `test_constants.go`.

## Release note

This introduces a new, default-on limit (`MaximumXMLTokens`, default 50000) on SAML response processing. Operators whose IdP emits unusually large documents (e.g. very large group-claim lists) should be aware they can raise it via `SAMLServiceProvider.MaximumXMLTokens` if legitimate responses are ever rejected.