### PR TITLE
Fix go vet copylocks failure in providertests

### DIFF
--- a/providertests/onelogin_test.go
+++ b/providertests/onelogin_test.go
@@ -188,15 +188,17 @@ var oneLoginAtTimes = map[int]string{
 }
 
 func TestOneLoginCasesLocally(t *testing.T) {
-	sp := &saml2.SAMLServiceProvider{
-		IdentityProviderSSOURL:      "https://saml.idp.nope/h9gkjzvb3e", // not required for these tests
-		IdentityProviderIssuer:      "https://saml.idp.nope/h9gkjzvb3e",
-		AssertionConsumerServiceURL: "https://saml.sp.nope/session/sso/saml/acs/rq5jwkvb8z",
-		AudienceURI:                 "https://saml.sp.nope/session/sso/saml/spentityid/rq5jwkvb8z",
-		IDPCertificateStore:         LoadCertificateStore("./testdata/onelogin/idp.signing.cert"),
-		SPKeyStore:                  LoadKeyStore("./testdata/onelogin/sp.encryption.cert", "./testdata/onelogin/sp.encryption.key"),
-		SPSigningKeyStore:           LoadKeyStore("./testdata/onelogin/sp.signing.cert", "./testdata/onelogin/sp.signing.key"),
-		ValidateEncryptionCert:      true,
+	newSP := func() *saml2.SAMLServiceProvider {
+		return &saml2.SAMLServiceProvider{
+			IdentityProviderSSOURL:      "https://saml.idp.nope/h9gkjzvb3e", // not required for these tests
+			IdentityProviderIssuer:      "https://saml.idp.nope/h9gkjzvb3e",
+			AssertionConsumerServiceURL: "https://saml.sp.nope/session/sso/saml/acs/rq5jwkvb8z",
+			AudienceURI:                 "https://saml.sp.nope/session/sso/saml/spentityid/rq5jwkvb8z",
+			IDPCertificateStore:         LoadCertificateStore("./testdata/onelogin/idp.signing.cert"),
+			SPKeyStore:                  LoadKeyStore("./testdata/onelogin/sp.encryption.cert", "./testdata/onelogin/sp.encryption.key"),
+			SPSigningKeyStore:           LoadKeyStore("./testdata/onelogin/sp.signing.cert", "./testdata/onelogin/sp.signing.key"),
+			ValidateEncryptionCert:      true,
+		}
 	}
 
 	scenarios := []ProviderTestScenario{}
@@ -205,7 +207,7 @@ func TestOneLoginCasesLocally(t *testing.T) {
 		scenarios = append(scenarios, ProviderTestScenario{
 			ScenarioName:     fmt.Sprintf("Scenario_%02d", idx),
 			Response:         response,
-			ServiceProvider:  spAtTime(sp, getAtTime(idx, oneLoginAtTimes), response),
+			ServiceProvider:  spAtTime(newSP, getAtTime(idx, oneLoginAtTimes), response),
 			CheckError:       scenarioErrorChecker(idx, oneLoginScenarioErrors),
 			CheckWarningInfo: scenarioWarningChecker(idx, oneLoginScenarioWarnings),
 		})

--- a/providertests/pingfed_test.go
+++ b/providertests/pingfed_test.go
@@ -54,15 +54,17 @@ var pingFedScenarioWarnings = map[int]scenarioWarnings{}
 var pingFedAtTimes = map[int]string{}
 
 func TestPingFedCasesLocally(t *testing.T) {
-	sp := &saml2.SAMLServiceProvider{
-		IdentityProviderSSOURL:      "https://saml.test.nope:9031/eid/sxpmrhbkzn", // not required for these tests
-		IdentityProviderIssuer:      "https://saml.test.nope:9031/eid/sxpmrhbkzn",
-		AssertionConsumerServiceURL: "https://saml.test.nope/session/sso/saml/acs/hp24dqnpvq",
-		AudienceURI:                 "https://saml.test.nope/session/sso/saml/spentityid/hp24dqnpvq",
-		IDPCertificateStore:         LoadCertificateStore("./testdata/pingfed/idp.signing.cert"),
-		SPKeyStore:                  LoadKeyStore("./testdata/pingfed/sp.encryption.cert", "./testdata/pingfed/sp.encryption.key"),
-		SPSigningKeyStore:           LoadKeyStore("./testdata/pingfed/sp.signing.cert", "./testdata/pingfed/sp.signing.key"),
-		ValidateEncryptionCert:      true,
+	newSP := func() *saml2.SAMLServiceProvider {
+		return &saml2.SAMLServiceProvider{
+			IdentityProviderSSOURL:      "https://saml.test.nope:9031/eid/sxpmrhbkzn", // not required for these tests
+			IdentityProviderIssuer:      "https://saml.test.nope:9031/eid/sxpmrhbkzn",
+			AssertionConsumerServiceURL: "https://saml.test.nope/session/sso/saml/acs/hp24dqnpvq",
+			AudienceURI:                 "https://saml.test.nope/session/sso/saml/spentityid/hp24dqnpvq",
+			IDPCertificateStore:         LoadCertificateStore("./testdata/pingfed/idp.signing.cert"),
+			SPKeyStore:                  LoadKeyStore("./testdata/pingfed/sp.encryption.cert", "./testdata/pingfed/sp.encryption.key"),
+			SPSigningKeyStore:           LoadKeyStore("./testdata/pingfed/sp.signing.cert", "./testdata/pingfed/sp.signing.key"),
+			ValidateEncryptionCert:      true,
+		}
 	}
 
 	scenarios := []ProviderTestScenario{}
@@ -71,7 +73,7 @@ func TestPingFedCasesLocally(t *testing.T) {
 		scenarios = append(scenarios, ProviderTestScenario{
 			ScenarioName:     fmt.Sprintf("Scenario_%02d", idx),
 			Response:         response,
-			ServiceProvider:  spAtTime(sp, getAtTime(idx, pingFedAtTimes), response),
+			ServiceProvider:  spAtTime(newSP, getAtTime(idx, pingFedAtTimes), response),
 			CheckError:       scenarioErrorChecker(idx, pingFedScenarioErrors),
 			CheckWarningInfo: scenarioWarningChecker(idx, pingFedScenarioWarnings),
 		})

--- a/providertests/utils.go
+++ b/providertests/utils.go
@@ -136,7 +136,7 @@ func getAtTime(idx int, scenarioAtTimes map[int]string) (atTime time.Time) {
 	return // zero time
 }
 
-func spAtTime(template *saml2.SAMLServiceProvider, atTime time.Time, rawResp string) *saml2.SAMLServiceProvider {
+func spAtTime(newSP func() *saml2.SAMLServiceProvider, atTime time.Time, rawResp string) *saml2.SAMLServiceProvider {
 	resp := &types.Response{}
 	if rawResp == "" {
 		panic(fmt.Errorf("empty rawResp"))
@@ -150,8 +150,7 @@ func spAtTime(template *saml2.SAMLServiceProvider, atTime time.Time, rawResp str
 		panic(fmt.Errorf("cannot parse Response XML: %v", err))
 	}
 
-	var sp saml2.SAMLServiceProvider
-	sp = *template // copy most fields template, we only set the clock below
+	sp := newSP() // fresh instance per scenario, we only set the clock below
 	if atTime.IsZero() {
 		// Prefer more official Assertion IssueInstant over Response IssueIntant
 		// (Assertion will be signed, either individually or as part of Response)
@@ -164,5 +163,5 @@ func spAtTime(template *saml2.SAMLServiceProvider, atTime time.Time, rawResp str
 		}
 	}
 	sp.Clock = dsig.NewFakeClock(clockwork.NewFakeClockAt(atTime))
-	return &sp
+	return sp
 }


### PR DESCRIPTION
## Before

```
$ go vet ./...
providertests/utils.go:154:7: assignment copies lock value to sp: github.com/russellhaering/gosaml2.SAMLServiceProvider contains sync.RWMutex
```

## Why the copy became invalid

`spAtTime` in `providertests/utils.go` took a template `*SAMLServiceProvider`, copied it by value (`sp = *template`), then set a per-scenario `Clock` on the copy and returned it. This let each test scenario get its own provider without repeating the whole struct literal.

`SAMLServiceProvider` now carries `signingContextMu sync.RWMutex` and a `signingContext` cache it lazily populates. Copying the struct by value copies the mutex too, which `go vet`'s `copylocks` check correctly flags — a copied `sync.RWMutex` is not safe to use independently of the original.

## Why a factory instead of a clone method or a field-by-field copy

- A `Clone()` method (or any other new exported API) on `SAMLServiceProvider` isn't warranted here — the mutex is deliberate, and the problem is on the test side, not the library's.
- A hand-written field-by-field copy would need to track all ~29 fields and silently stop copying new ones as they're added, quietly changing test behavior over time.
- Instead, `spAtTime` now takes a `newSP func() *saml2.SAMLServiceProvider` constructor and calls it once per scenario, so each scenario gets a genuinely independent, freshly built provider. The two call sites (`onelogin_test.go`, `pingfed_test.go`) now wrap their existing struct literal in a closure rather than building one shared instance up front.

Both `sp` variables were only referenced once, at the `spAtTime` call site inside the scenario-building loop, so no other logic needed to change. Scenarios are accumulated into a slice and only exercised afterward by `ExerciseProviderTestScenarios`, so a shared instance mutated in place across iterations was never viable — each entry needs its own `Clock`.

## After

```
$ go vet ./...
$
```

Clean, no findings. `go build ./...` and `go test ./...` also pass, including all of `providertests/` (multiple scenarios depend on time-sensitive assertions, e.g. expired certs and `NotOnOrAfter`, so a regression collapsing all scenarios onto one shared clock would have shown up as test failures).

This doesn't affect CI today — the Test workflow only runs `go test ./...`, and `copylocks` isn't part of the vet subset `go test` runs — but it will the moment a vet or lint step is added.