### PR TITLE
Support NameID-valued attributes and NameID qualifiers

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -20,6 +20,16 @@ import "github.com/russellhaering/gosaml2/types"
 // can be used for easy access to the string values of Attribute lists.
 type Values map[string]types.Attribute
 
+// valueString returns the string form of an AttributeValue: the value of a
+// nested NameID element if one is present (e.g. eduPersonTargetedID),
+// otherwise the text content.
+func valueString(v types.AttributeValue) string {
+	if v.NameID != nil && v.NameID.Value != "" {
+		return v.NameID.Value
+	}
+	return v.Value
+}
+
 // Get is a safe method (nil maps will not panic) for returning the first value
 // for an attribute at a key, or the empty string if none exists.
 func (vals Values) Get(k string) string {
@@ -27,7 +37,7 @@ func (vals Values) Get(k string) string {
 		return ""
 	}
 	if v, ok := vals[k]; ok && len(v.Values) > 0 {
-		return string(v.Values[0].Value)
+		return valueString(v.Values[0])
 	}
 	return ""
 }
@@ -58,7 +68,7 @@ func (vals Values) GetAll(k string) []string {
 
 	if v, ok := vals[k]; ok && len(v.Values) > 0 {
 		for i := 0; i < len(v.Values); i++ {
-			av = append(av, string(v.Values[i].Value))
+			av = append(av, valueString(v.Values[i]))
 		}
 	}
 

--- a/attribute_test.go
+++ b/attribute_test.go
@@ -1,0 +1,64 @@
+// Copyright 2026 Russell Haering et al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package saml2
+
+import (
+	"encoding/xml"
+	"testing"
+
+	"github.com/russellhaering/gosaml2/types"
+	"github.com/stretchr/testify/require"
+)
+
+const nameIDAttributeStatement = `
+<saml2:AttributeStatement xmlns:saml2="urn:oasis:names:tc:SAML:2.0:assertion">
+	<saml2:Attribute Name="urn:oid:1.3.6.1.4.1.5923.1.1.1.10" FriendlyName="eduPersonTargetedID">
+		<saml2:AttributeValue>
+			<saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
+				NameQualifier="https://idp.example.edu/idp/shibboleth"
+				SPNameQualifier="https://sp.example.com/shibboleth">a1b2c3d4e5f6</saml2:NameID>
+		</saml2:AttributeValue>
+	</saml2:Attribute>
+	<saml2:Attribute Name="Email">
+		<saml2:AttributeValue>phoebe.simon@scaleft.com</saml2:AttributeValue>
+	</saml2:Attribute>
+</saml2:AttributeStatement>`
+
+func TestValuesWithNameIDAttributeValue(t *testing.T) {
+	statement := &types.AttributeStatement{}
+	err := xml.Unmarshal([]byte(nameIDAttributeStatement), statement)
+	require.NoError(t, err)
+
+	vals := make(Values)
+	for _, attribute := range statement.Attributes {
+		vals[attribute.Name] = attribute
+	}
+
+	// A NameID-valued attribute yields the NameID's value from Get and GetAll.
+	require.Equal(t, "a1b2c3d4e5f6", vals.Get("urn:oid:1.3.6.1.4.1.5923.1.1.1.10"))
+	require.Equal(t, []string{"a1b2c3d4e5f6"}, vals.GetAll("urn:oid:1.3.6.1.4.1.5923.1.1.1.10"))
+
+	// Plain text attributes are unaffected.
+	require.Equal(t, "phoebe.simon@scaleft.com", vals.Get("Email"))
+	require.Equal(t, []string{"phoebe.simon@scaleft.com"}, vals.GetAll("Email"))
+
+	// The nested NameID and its qualifiers are accessible directly.
+	nameID := statement.Attributes[0].Values[0].NameID
+	require.NotNil(t, nameID)
+	require.Equal(t, "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent", nameID.Format)
+	require.Equal(t, "https://idp.example.edu/idp/shibboleth", nameID.NameQualifier)
+	require.Equal(t, "https://sp.example.com/shibboleth", nameID.SPNameQualifier)
+	require.Equal(t, "a1b2c3d4e5f6", nameID.Value)
+}

--- a/types/response.go
+++ b/types/response.go
@@ -109,9 +109,11 @@ type AuthnContextClassRef struct {
 }
 
 type NameID struct {
-	XMLName xml.Name `xml:"urn:oasis:names:tc:SAML:2.0:assertion NameID"`
-	Format  string   `xml:"Format,attr,omitempty"`
-	Value   string   `xml:",chardata"`
+	XMLName         xml.Name `xml:"urn:oasis:names:tc:SAML:2.0:assertion NameID"`
+	Format          string   `xml:"Format,attr,omitempty"`
+	NameQualifier   string   `xml:"NameQualifier,attr,omitempty"`
+	SPNameQualifier string   `xml:"SPNameQualifier,attr,omitempty"`
+	Value           string   `xml:",chardata"`
 }
 
 type SubjectConfirmation struct {
@@ -173,6 +175,10 @@ type AttributeValue struct {
 	XMLName xml.Name `xml:"urn:oasis:names:tc:SAML:2.0:assertion AttributeValue"`
 	Type    string   `xml:"xsi:type,attr"`
 	Value   string   `xml:",chardata"`
+	// NameID is set when the attribute value is a NameID element rather than
+	// text content, as with eduPersonTargetedID. In that case Value holds only
+	// surrounding whitespace, if anything.
+	NameID *NameID `xml:"NameID"`
 }
 
 type AuthnStatement struct {


### PR DESCRIPTION
Forward-port of #80 by @joernlenoch — thanks for the original contribution; this supersedes that PR and credits it via a `Co-authored-by` trailer.

## What this does

- Parses a nested `NameID` element on `AttributeValue`. Some IdPs (notably Shibboleth-style deployments issuing `eduPersonTargetedID`) emit attributes whose value is a NameID element rather than text. Because `encoding/xml` chardata does not descend into child elements, `Values.Get`/`Values.GetAll` previously returned an empty string for such attributes.
- `Values.Get` **and** `Values.GetAll` now fall back to the nested NameID's value (#80 only covered `Get`, which would have left the two accessors disagreeing).
- Adds `NameQualifier`/`SPNameQualifier` to `types.NameID` with explicit attr tags. These are part of NameID identity and must be preserved when echoing a NameID back to the IdP (e.g. in a LogoutRequest). #80's `Format` field was delivered separately by #280.
- Adds test coverage (a fixture with a NameID-valued attribute alongside a plain text attribute); #80 had none.

Low regression risk: for NameID-valued attributes the accessors currently return `""`, so no caller is losing a useful value.