### PR TITLE
Add ClockSkew tolerance to time-based assertion validation

### DIFF
--- a/clock_skew_test.go
+++ b/clock_skew_test.go
@@ -1,0 +1,133 @@
+// Copyright 2026 Russell Haering et al.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package saml2
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/beevik/etree"
+	"github.com/stretchr/testify/require"
+)
+
+// signResponseWithTimes rewrites the time bounds on a fixture response so
+// that clock skew scenarios can be expressed relative to the test clock,
+// then re-signs it.
+func signResponseWithTimes(t *testing.T, resp string, sp *SAMLServiceProvider, notBefore, notOnOrAfter, subjectNotOnOrAfter time.Time) string {
+	t.Helper()
+
+	doc := etree.NewDocument()
+	err := doc.ReadFromBytes([]byte(resp))
+	require.NoError(t, err)
+
+	assertionEl := doc.Root().SelectElement("saml2:Assertion")
+	require.NotNil(t, assertionEl)
+
+	conditionsEl := assertionEl.SelectElement("saml2:Conditions")
+	require.NotNil(t, conditionsEl)
+
+	notBeforeAttr := conditionsEl.SelectAttr("NotBefore")
+	require.NotNil(t, notBeforeAttr)
+	notBeforeAttr.Value = notBefore.Format(time.RFC3339)
+
+	notOnOrAfterAttr := conditionsEl.SelectAttr("NotOnOrAfter")
+	require.NotNil(t, notOnOrAfterAttr)
+	notOnOrAfterAttr.Value = notOnOrAfter.Format(time.RFC3339)
+
+	subjectConfirmationDataEl := assertionEl.FindElement("./saml2:Subject/saml2:SubjectConfirmation/saml2:SubjectConfirmationData")
+	require.NotNil(t, subjectConfirmationDataEl)
+
+	subjectNotOnOrAfterAttr := subjectConfirmationDataEl.SelectAttr("NotOnOrAfter")
+	require.NotNil(t, subjectNotOnOrAfterAttr)
+	subjectNotOnOrAfterAttr.Value = subjectNotOnOrAfter.Format(time.RFC3339)
+
+	str, err := doc.WriteToString()
+	require.NoError(t, err)
+
+	return signResponse(t, str, sp)
+}
+
+func TestClockSkew(t *testing.T) {
+	// The fake clock in getSAMLServiceProvider is pinned to this instant.
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	newSP := func(t *testing.T) *SAMLServiceProvider {
+		ks := testKeyStore(t, now)
+		_, _cert, err := ks.GetKeyPair()
+		require.NoError(t, err)
+		sp := getSAMLServiceProvider(t, _cert)
+		sp.SPKeyStore = ks
+		return sp
+	}
+
+	t.Run("NotBeforeInFuture", func(t *testing.T) {
+		sp := newSP(t)
+		raw := signResponseWithTimes(t, rawResponse, sp,
+			now.Add(3*time.Minute), now.Add(time.Hour), now.Add(time.Hour))
+		encoded := base64.StdEncoding.EncodeToString([]byte(raw))
+
+		info, err := sp.RetrieveAssertionInfo(encoded)
+		require.NoError(t, err)
+		require.True(t, info.WarningInfo.InvalidTime)
+
+		sp.ClockSkew = 4 * time.Minute
+		info, err = sp.RetrieveAssertionInfo(encoded)
+		require.NoError(t, err)
+		require.False(t, info.WarningInfo.InvalidTime)
+	})
+
+	t.Run("ConditionsExpired", func(t *testing.T) {
+		sp := newSP(t)
+		raw := signResponseWithTimes(t, rawResponse, sp,
+			now.Add(-time.Hour), now.Add(-5*time.Minute), now.Add(time.Hour))
+		encoded := base64.StdEncoding.EncodeToString([]byte(raw))
+
+		info, err := sp.RetrieveAssertionInfo(encoded)
+		require.NoError(t, err)
+		require.True(t, info.WarningInfo.InvalidTime)
+
+		sp.ClockSkew = 6 * time.Minute
+		info, err = sp.RetrieveAssertionInfo(encoded)
+		require.NoError(t, err)
+		require.False(t, info.WarningInfo.InvalidTime)
+	})
+
+	t.Run("SubjectConfirmationExpired", func(t *testing.T) {
+		sp := newSP(t)
+		raw := signResponseWithTimes(t, rawResponse, sp,
+			now.Add(-time.Hour), now.Add(time.Hour), now.Add(-5*time.Minute))
+		encoded := base64.StdEncoding.EncodeToString([]byte(raw))
+
+		_, err := sp.RetrieveAssertionInfo(encoded)
+		require.Error(t, err)
+
+		sp.ClockSkew = 6 * time.Minute
+		info, err := sp.RetrieveAssertionInfo(encoded)
+		require.NoError(t, err)
+		require.False(t, info.WarningInfo.InvalidTime)
+	})
+
+	t.Run("NotOnOrAfterIsExclusive", func(t *testing.T) {
+		sp := newSP(t)
+		raw := signResponseWithTimes(t, rawResponse, sp,
+			now.Add(-time.Hour), now, now.Add(time.Hour))
+		encoded := base64.StdEncoding.EncodeToString([]byte(raw))
+
+		info, err := sp.RetrieveAssertionInfo(encoded)
+		require.NoError(t, err)
+		require.True(t, info.WarningInfo.InvalidTime)
+	})
+}

--- a/saml.go
+++ b/saml.go
@@ -74,6 +74,13 @@ type SAMLServiceProvider struct {
 	AllowMissingAttributes  bool
 	Clock                   *dsig.Clock
 
+	// ClockSkew is the tolerance applied to time-based validation of
+	// assertions (the Conditions NotBefore and NotOnOrAfter bounds, and the
+	// SubjectConfirmationData NotOnOrAfter bound) to accommodate clock drift
+	// between the identity provider and this service provider. The zero value
+	// applies no tolerance.
+	ClockSkew time.Duration
+
 	// Required encryption key and default signing key.
 	// Deprecated: Use SetSPKeyStore instead of setting or reading this field.
 	SPKeyStore dsig.X509KeyStore

--- a/validate.go
+++ b/validate.go
@@ -77,7 +77,7 @@ func (sp *SAMLServiceProvider) VerifyAssertionConditions(assertion *types.Assert
 		return nil, ErrParsing{Tag: NotBeforeAttr, Value: conditions.NotBefore, Type: "time.RFC3339"}
 	}
 
-	if now.Before(notBefore) {
+	if now.Add(sp.ClockSkew).Before(notBefore) {
 		warningInfo.InvalidTime = true
 	}
 
@@ -90,7 +90,9 @@ func (sp *SAMLServiceProvider) VerifyAssertionConditions(assertion *types.Assert
 		return nil, ErrParsing{Tag: NotOnOrAfterAttr, Value: conditions.NotOnOrAfter, Type: "time.RFC3339"}
 	}
 
-	if now.After(notOnOrAfter) {
+	// NotOnOrAfter is an exclusive bound: a time exactly equal to it is
+	// outside the validity window.
+	if !now.Before(notOnOrAfter.Add(sp.ClockSkew)) {
 		warningInfo.InvalidTime = true
 	}
 
@@ -230,7 +232,7 @@ func (sp *SAMLServiceProvider) Validate(response *types.Response) error {
 		}
 
 		now := sp.Clock.Now()
-		if now.After(notOnOrAfter) {
+		if !now.Before(notOnOrAfter.Add(sp.ClockSkew)) {
 			return ErrInvalidValue{
 				Reason:   ReasonExpired,
 				Key:      NotOnOrAfterAttr,


### PR DESCRIPTION
Forward-port of #71 by @konaraya — thanks for the original contribution, including the test approach; this supersedes that PR and credits it via a `Co-authored-by` trailer. Fixes #101.

## What this does

Clock drift between an IdP and SP causes intermittent login failures when assertions arrive with a `NotBefore` slightly in the future, or expire moments before validation (#101's example is a 31ms drift). This adds a `ClockSkew time.Duration` field to `SAMLServiceProvider`, applied uniformly to all three time-based validations:

- `Conditions` `NotBefore` and `NotOnOrAfter` (the `WarningInfo.InvalidTime` path)
- `SubjectConfirmationData` `NotOnOrAfter` (the hard-reject path in `Validate`)

The zero value applies no tolerance, preserving existing behavior. Skew can't be emulated via the pluggable `Clock`, since the bounds need slack in opposite directions.

## Changes from #71

- Rebased across six years of drift; simplified the comparisons (`now.Add(sp.ClockSkew).Before(notBefore)` instead of the double-`Sub` formulation).
- Fixed a pre-existing boundary bug in passing: `NotOnOrAfter` is an **exclusive** bound per SAML Core ("on or after" is invalid), but the old `now.After(...)` comparisons treated exactly-equal as valid.
- Rewrote the tests in the current per-scenario style with the pinned fake clock, so they're deterministic; added coverage for the hard-reject path and the exclusive boundary.